### PR TITLE
Remove marquez healthcheck in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,12 +37,6 @@ services:
       - ./docker/marquez.yml:/usr/src/app/config.yml
     depends_on:
       - marquez_db
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:5001/ping"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 30s
 
   marquez_db:
     image: "postgres:9.6"

--- a/docker/db/wait-for-marquez.sh
+++ b/docker/db/wait-for-marquez.sh
@@ -18,7 +18,7 @@ set -eu
 
 host="${1}"
 port="${2}"
-timeout="${3:-10}"
+timeout="${3:-30}"
 
 until curl --output /dev/null --silent --head --fail "http://${host}:${port}/ping"; do
   echo "Waiting for Marquez to become available..."


### PR DESCRIPTION
This PR removes the use of `healthcheck` as it's not needed for container dependencies in favor of [`wait-for-marquez.sh`](https://github.com/MarquezProject/marquez-web/blob/master/docker/db/wait-for-marquez.sh).
