### PR TITLE
feature/sql-styling

### DIFF
--- a/src/components/JobDetailPage.tsx
+++ b/src/components/JobDetailPage.tsx
@@ -86,12 +86,13 @@ const styles = ({ palette, spacing, shadows }: ITheme) => {
       borderLeft: '2rem solid white'
     },
     SQLModalTitle: {
+      backgroundColor: 'white',
+      paddingTop: '1rem',
       fontSize: '2rem',
       fontWeight: 700,
       position: 'fixed',
-      width: '100%',
-      right: 0,
-      marginTop: '1rem'
+      width: '80%',
+      right: '10%'
     },
     copyToClipboard: {
       position: 'absolute',


### PR DESCRIPTION
### Description

This PR resolves the issue with the SQL modal title styling. Previously, text was showing up behind it when scrolling.

Before:
![Screen Shot 2019-12-09 at 12 26 24 PM](https://user-images.githubusercontent.com/1332789/70752934-ab0ab580-1d01-11ea-9116-62f433fca387.png)

After:
![Screen Shot 2019-12-09 at 12 28 45 PM](https://user-images.githubusercontent.com/1332789/70753047-e1483500-1d01-11ea-8ff9-fb3cb9569dd6.png)


### Checklist

- [ ] This PR contains tests (at least one (non-snapshot) test)
