### PR TITLE
Feature/re add filters

### DIFF
--- a/src/__tests__/components/__snapshots__/DatasetDetailPage.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/DatasetDetailPage.test.tsx.snap
@@ -2556,9 +2556,12 @@ exports[`DatasetDetailPage Component when there is a match for the datasetName i
                     className="tagWrapper"
                     classes={
                       Object {
+                        "arrow": "MuiTooltip-arrow",
                         "popper": "MuiTooltip-popper",
+                        "popperArrow": "MuiTooltip-popperArrow",
                         "popperInteractive": "MuiTooltip-popperInteractive",
                         "tooltip": "MuiTooltip-tooltip",
+                        "tooltipArrow": "MuiTooltip-tooltipArrow",
                         "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom",
                         "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft",
                         "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight",
@@ -2646,6 +2649,16 @@ exports[`DatasetDetailPage Component when there is a match for the datasetName i
                       id={null}
                       open={false}
                       placement="top"
+                      popperOptions={
+                        Object {
+                          "modifiers": Object {
+                            "arrow": Object {
+                              "element": null,
+                              "enabled": false,
+                            },
+                          },
+                        }
+                      }
                       transition={true}
                     />
                   </ForwardRef(Tooltip)>
@@ -2663,9 +2676,12 @@ exports[`DatasetDetailPage Component when there is a match for the datasetName i
                     className="tagWrapper"
                     classes={
                       Object {
+                        "arrow": "MuiTooltip-arrow",
                         "popper": "MuiTooltip-popper",
+                        "popperArrow": "MuiTooltip-popperArrow",
                         "popperInteractive": "MuiTooltip-popperInteractive",
                         "tooltip": "MuiTooltip-tooltip",
+                        "tooltipArrow": "MuiTooltip-tooltipArrow",
                         "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom",
                         "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft",
                         "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight",
@@ -2753,6 +2769,16 @@ exports[`DatasetDetailPage Component when there is a match for the datasetName i
                       id={null}
                       open={false}
                       placement="top"
+                      popperOptions={
+                        Object {
+                          "modifiers": Object {
+                            "arrow": Object {
+                              "element": null,
+                              "enabled": false,
+                            },
+                          },
+                        }
+                      }
                       transition={true}
                     />
                   </ForwardRef(Tooltip)>
@@ -2882,9 +2908,12 @@ exports[`DatasetDetailPage Component when there is a match for the datasetName i
                                         <ForwardRef(Tooltip)
                                           classes={
                                             Object {
+                                              "arrow": "MuiTooltip-arrow",
                                               "popper": "MuiTooltip-popper",
+                                              "popperArrow": "MuiTooltip-popperArrow",
                                               "popperInteractive": "MuiTooltip-popperInteractive",
                                               "tooltip": "MuiTooltip-tooltip",
+                                              "tooltipArrow": "MuiTooltip-tooltipArrow",
                                               "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom",
                                               "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft",
                                               "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight",
@@ -2951,6 +2980,16 @@ exports[`DatasetDetailPage Component when there is a match for the datasetName i
                                             id={null}
                                             open={false}
                                             placement="top"
+                                            popperOptions={
+                                              Object {
+                                                "modifiers": Object {
+                                                  "arrow": Object {
+                                                    "element": null,
+                                                    "enabled": false,
+                                                  },
+                                                },
+                                              }
+                                            }
                                             transition={true}
                                           />
                                         </ForwardRef(Tooltip)>
@@ -2998,9 +3037,12 @@ exports[`DatasetDetailPage Component when there is a match for the datasetName i
                                         <ForwardRef(Tooltip)
                                           classes={
                                             Object {
+                                              "arrow": "MuiTooltip-arrow",
                                               "popper": "MuiTooltip-popper",
+                                              "popperArrow": "MuiTooltip-popperArrow",
                                               "popperInteractive": "MuiTooltip-popperInteractive",
                                               "tooltip": "MuiTooltip-tooltip",
+                                              "tooltipArrow": "MuiTooltip-tooltipArrow",
                                               "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom",
                                               "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft",
                                               "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight",
@@ -3067,6 +3109,16 @@ exports[`DatasetDetailPage Component when there is a match for the datasetName i
                                             id={null}
                                             open={false}
                                             placement="top"
+                                            popperOptions={
+                                              Object {
+                                                "modifiers": Object {
+                                                  "arrow": Object {
+                                                    "element": null,
+                                                    "enabled": false,
+                                                  },
+                                                },
+                                              }
+                                            }
                                             transition={true}
                                           />
                                         </ForwardRef(Tooltip)>
@@ -3114,9 +3166,12 @@ exports[`DatasetDetailPage Component when there is a match for the datasetName i
                                         <ForwardRef(Tooltip)
                                           classes={
                                             Object {
+                                              "arrow": "MuiTooltip-arrow",
                                               "popper": "MuiTooltip-popper",
+                                              "popperArrow": "MuiTooltip-popperArrow",
                                               "popperInteractive": "MuiTooltip-popperInteractive",
                                               "tooltip": "MuiTooltip-tooltip",
+                                              "tooltipArrow": "MuiTooltip-tooltipArrow",
                                               "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom",
                                               "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft",
                                               "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight",
@@ -3183,6 +3238,16 @@ exports[`DatasetDetailPage Component when there is a match for the datasetName i
                                             id={null}
                                             open={false}
                                             placement="top"
+                                            popperOptions={
+                                              Object {
+                                                "modifiers": Object {
+                                                  "arrow": Object {
+                                                    "element": null,
+                                                    "enabled": false,
+                                                  },
+                                                },
+                                              }
+                                            }
                                             transition={true}
                                           />
                                         </ForwardRef(Tooltip)>
@@ -3230,9 +3295,12 @@ exports[`DatasetDetailPage Component when there is a match for the datasetName i
                                         <ForwardRef(Tooltip)
                                           classes={
                                             Object {
+                                              "arrow": "MuiTooltip-arrow",
                                               "popper": "MuiTooltip-popper",
+                                              "popperArrow": "MuiTooltip-popperArrow",
                                               "popperInteractive": "MuiTooltip-popperInteractive",
                                               "tooltip": "MuiTooltip-tooltip",
+                                              "tooltipArrow": "MuiTooltip-tooltipArrow",
                                               "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom",
                                               "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft",
                                               "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight",
@@ -3299,6 +3367,16 @@ exports[`DatasetDetailPage Component when there is a match for the datasetName i
                                             id={null}
                                             open={false}
                                             placement="top"
+                                            popperOptions={
+                                              Object {
+                                                "modifiers": Object {
+                                                  "arrow": Object {
+                                                    "element": null,
+                                                    "enabled": false,
+                                                  },
+                                                },
+                                              }
+                                            }
                                             transition={true}
                                           />
                                         </ForwardRef(Tooltip)>
@@ -3346,9 +3424,12 @@ exports[`DatasetDetailPage Component when there is a match for the datasetName i
                                         <ForwardRef(Tooltip)
                                           classes={
                                             Object {
+                                              "arrow": "MuiTooltip-arrow",
                                               "popper": "MuiTooltip-popper",
+                                              "popperArrow": "MuiTooltip-popperArrow",
                                               "popperInteractive": "MuiTooltip-popperInteractive",
                                               "tooltip": "MuiTooltip-tooltip",
+                                              "tooltipArrow": "MuiTooltip-tooltipArrow",
                                               "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom",
                                               "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft",
                                               "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight",
@@ -3415,6 +3496,16 @@ exports[`DatasetDetailPage Component when there is a match for the datasetName i
                                             id={null}
                                             open={false}
                                             placement="top"
+                                            popperOptions={
+                                              Object {
+                                                "modifiers": Object {
+                                                  "arrow": Object {
+                                                    "element": null,
+                                                    "enabled": false,
+                                                  },
+                                                },
+                                              }
+                                            }
                                             transition={true}
                                           />
                                         </ForwardRef(Tooltip)>

--- a/src/__tests__/components/__snapshots__/Filters.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/Filters.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Filters component renders a snapshot that matches previous 1`] = `
 <Styled(MuiBox)
-  ml="5%"
+  ml="0.5rem"
   py={2}
 >
   <WithStyles(WithStyles(ForwardRef(FormControl)))

--- a/src/components/Filters.tsx
+++ b/src/components/Filters.tsx
@@ -85,7 +85,7 @@ const Filters = (props: IProps): ReactElement => {
   }
 
   return (
-    <Box ml='5%' py={2}>
+    <Box ml='0.5rem' py={2}>
       <StyledFormControl margin='normal'>
         <InputLabel id='filter-by-label'>Filter by</InputLabel>
         <MUISelect value={currentFilter} renderValue={capitalize} onChange={onPrimaryFilterChange}>

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -66,8 +66,8 @@ class Home extends React.Component<IAllProps, IState> {
     const matchingJobs = jobs.filter(j => j.matches)
     return (
       <div>
-        <FilterContainer showJobs={setShowJobs} />
         <div className={classes.row}>
+          <FilterContainer showJobs={setShowJobs} />
           <Box className={classes.column}>
             {matchingDatasets.length > 0 ? (
               <Typography className={classes.header} color='secondary' variant='h3'>

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -26,7 +26,9 @@ const styles = (_theme: ITheme) => {
     },
     row: {
       display: 'flex',
-      flexDirection: 'row',
+      flexDirection: 'row'
+    },
+    lowerHalf: {
       padding: '52vh 5% 1%',
       position: 'absolute',
       top: 0,
@@ -65,48 +67,50 @@ class Home extends React.Component<IAllProps, IState> {
     const matchingDatasets = datasets.filter(d => d.matches)
     const matchingJobs = jobs.filter(j => j.matches)
     return (
-      <div className="jilladded">
-        <FilterContainer showJobs={setShowJobs} />
-        <div className={classes.row}>
-          <Box className={classes.column}>
-            {matchingDatasets.length > 0 ? (
-              <Typography className={classes.header} color='secondary' variant='h3'>
-                {!showJobs ? 'Popular Datasets' : 'Matching Datasets'}
-              </Typography>
-            ) : (
-              <Typography className={classes.noDatasets}>no datasets found!</Typography>
-            )}
-            {matchingDatasets.map(d => (
-              <DatasetPreviewCard
-                key={d.name}
-                name={d.name}
-                description={d.description}
-                updatedAt={d.createdAt}
-              />
-            ))}
-          </Box>
-          {showJobs ? (
+      <div>
+        <Box display='flex' flexDirection='column' justifyContent='center' className={classes.lowerHalf}>
+          <FilterContainer showJobs={setShowJobs} />
+          <div className={classes.row}>
             <Box className={classes.column}>
-              {matchingJobs.length > 0 ? (
+              {matchingDatasets.length > 0 ? (
                 <Typography className={classes.header} color='secondary' variant='h3'>
-                  Matching Jobs
+                  {!showJobs ? 'Popular Datasets' : 'Matching Datasets'}
                 </Typography>
               ) : (
-                <Typography className={classes.noJobs}>no jobs found!</Typography>
+                <Typography className={classes.noDatasets}>no datasets found!</Typography>
               )}
-              {matchingJobs.map(d => (
-                <JobPreviewCard
-                  /* should change to unique identifier */
+              {matchingDatasets.map(d => (
+                <DatasetPreviewCard
                   key={d.name}
                   name={d.name}
                   description={d.description}
                   updatedAt={d.createdAt}
-                  status={d.status}
                 />
               ))}
             </Box>
-          ) : null}
-        </div>
+            {showJobs ? (
+              <Box className={classes.column}>
+                {matchingJobs.length > 0 ? (
+                  <Typography className={classes.header} color='secondary' variant='h3'>
+                    Matching Jobs
+                  </Typography>
+                ) : (
+                  <Typography className={classes.noJobs}>no jobs found!</Typography>
+                )}
+                {matchingJobs.map(d => (
+                  <JobPreviewCard
+                    /* should change to unique identifier */
+                    key={d.name}
+                    name={d.name}
+                    description={d.description}
+                    updatedAt={d.createdAt}
+                    status={d.status}
+                  />
+                ))}
+              </Box>
+            ) : null}
+          </div>
+        </Box>
       </div>
     )
   }

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -65,9 +65,9 @@ class Home extends React.Component<IAllProps, IState> {
     const matchingDatasets = datasets.filter(d => d.matches)
     const matchingJobs = jobs.filter(j => j.matches)
     return (
-      <div>
+      <div className="jilladded">
+        <FilterContainer showJobs={setShowJobs} />
         <div className={classes.row}>
-          <FilterContainer showJobs={setShowJobs} />
           <Box className={classes.column}>
             {matchingDatasets.length > 0 ? (
               <Typography className={classes.header} color='secondary' variant='h3'>


### PR DESCRIPTION
### Description

This PR adds the filters back to the page. (When we moved the network graph to its own container, they went missing.) I wrapped the filters and the rest of the lower portion of the page in a new Box and styled that.

![Screen Shot 2019-12-13 at 2 54 27 PM](https://user-images.githubusercontent.com/1332789/70828133-c4bb0400-1db8-11ea-8abc-bc6ec637fbea.png)


### Checklist

- [ ] This PR contains tests (at least one (non-snapshot) test)
