### PR TITLE
Feature/add message when no dataset fields

### DIFF
--- a/docker/db/data/datasets.json
+++ b/docker/db/data/datasets.json
@@ -66,28 +66,7 @@
     "sourceName": "snowflake",
     "namespace": "galactic-data",
     "description": "all trips taken through the galaxy",
-    "fields": [
-      {
-      "name": "uuid",
-      "type": "STRING"
-      },
-      {
-      "name": "name",
-      "type": "STRING"
-      },
-      {
-      "name": "mass",
-      "type": "INTEGER"
-      },
-      {
-      "name": "dimension",
-      "type": "STRING"
-      },
-      {
-      "name": "interstellar",
-      "type": "BOOLEAN"
-      }
-    ]
+    "fields": []
   },
   {
     "name": "earth.dimensions",
@@ -216,28 +195,7 @@
     "namespace": "galactic-data",
     "sourceName": "redshift",
     "description": "describes all life",
-    "fields": [
-      {
-      "name": "uuid",
-      "type": "STRING"
-      },
-      {
-      "name": "name",
-      "type": "STRING"
-      },
-      {
-      "name": "mass",
-      "type": "INTEGER"
-      },
-      {
-      "name": "dimension",
-      "type": "STRING"
-      },
-      {
-      "name": "interstellar",
-      "type": "BOOLEAN"
-      }
-    ]
+    "fields": []
   },
   {
     "name": "environment.universe",

--- a/docker/db/data/datasets.json
+++ b/docker/db/data/datasets.json
@@ -203,29 +203,7 @@
     "type": "DB_TABLE",
     "namespace": "galactic-data",
     "sourceName": "redshift",
-    "description": "describes the entire universe",
-    "fields": [
-      {
-      "name": "uuid",
-      "type": "STRING"
-      },
-      {
-      "name": "name",
-      "type": "STRING"
-      },
-      {
-      "name": "mass",
-      "type": "INTEGER"
-      },
-      {
-      "name": "dimension",
-      "type": "STRING"
-      },
-      {
-      "name": "interstellar",
-      "type": "BOOLEAN"
-      }
-    ]
+    "description": "describes the entire universe"
   },
   {
     "name": "galaxy.radiowaves",

--- a/src/__tests__/components/__snapshots__/DatasetDetailPage.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/DatasetDetailPage.test.tsx.snap
@@ -66,28 +66,7 @@ exports[`DatasetDetailPage Component when there is a match for the datasetName i
       },
       Object {
         "description": "all trips taken through the galaxy",
-        "fields": Array [
-          Object {
-            "name": "uuid",
-            "type": "STRING",
-          },
-          Object {
-            "name": "name",
-            "type": "STRING",
-          },
-          Object {
-            "name": "mass",
-            "type": "INTEGER",
-          },
-          Object {
-            "name": "dimension",
-            "type": "STRING",
-          },
-          Object {
-            "name": "interstellar",
-            "type": "BOOLEAN",
-          },
-        ],
+        "fields": Array [],
         "name": "galaxy.trips",
         "namespace": "galactic-data",
         "physicalName": "galaxy.trips",
@@ -216,28 +195,7 @@ exports[`DatasetDetailPage Component when there is a match for the datasetName i
       },
       Object {
         "description": "describes all life",
-        "fields": Array [
-          Object {
-            "name": "uuid",
-            "type": "STRING",
-          },
-          Object {
-            "name": "name",
-            "type": "STRING",
-          },
-          Object {
-            "name": "mass",
-            "type": "INTEGER",
-          },
-          Object {
-            "name": "dimension",
-            "type": "STRING",
-          },
-          Object {
-            "name": "interstellar",
-            "type": "BOOLEAN",
-          },
-        ],
+        "fields": Array [],
         "name": "objects.life",
         "namespace": "galactic-data",
         "physicalName": "objects.life",
@@ -1210,16 +1168,18 @@ exports[`DatasetDetailPage Component when there is a match for the datasetName i
   <DatasetDetailPage
     classes={
       Object {
-        "closeButton": "DatasetDetailPage-closeButton-9",
-        "infoIcon": "DatasetDetailPage-infoIcon-4",
+        "closeButton": "DatasetDetailPage-closeButton-11",
+        "infoIcon": "DatasetDetailPage-infoIcon-6",
         "noData": "DatasetDetailPage-noData-3",
-        "paper": "DatasetDetailPage-paper-7",
+        "noSchema": "DatasetDetailPage-noSchema-4",
+        "noSchemaTitle": "DatasetDetailPage-noSchemaTitle-5",
+        "paper": "DatasetDetailPage-paper-9",
         "root": "DatasetDetailPage-root-1",
-        "tableCell": "DatasetDetailPage-tableCell-5",
-        "tableRow": "DatasetDetailPage-tableRow-6",
+        "tableCell": "DatasetDetailPage-tableCell-7",
+        "tableRow": "DatasetDetailPage-tableRow-8",
         "tagContainer": "DatasetDetailPage-tagContainer-2",
-        "tagHolder": "DatasetDetailPage-tagHolder-10",
-        "updated": "DatasetDetailPage-updated-8",
+        "tagHolder": "DatasetDetailPage-tagHolder-12",
+        "updated": "DatasetDetailPage-updated-10",
       }
     }
     datasets={
@@ -1286,28 +1246,7 @@ exports[`DatasetDetailPage Component when there is a match for the datasetName i
         },
         Object {
           "description": "all trips taken through the galaxy",
-          "fields": Array [
-            Object {
-              "name": "uuid",
-              "type": "STRING",
-            },
-            Object {
-              "name": "name",
-              "type": "STRING",
-            },
-            Object {
-              "name": "mass",
-              "type": "INTEGER",
-            },
-            Object {
-              "name": "dimension",
-              "type": "STRING",
-            },
-            Object {
-              "name": "interstellar",
-              "type": "BOOLEAN",
-            },
-          ],
+          "fields": Array [],
           "name": "galaxy.trips",
           "namespace": "galactic-data",
           "physicalName": "galaxy.trips",
@@ -1436,28 +1375,7 @@ exports[`DatasetDetailPage Component when there is a match for the datasetName i
         },
         Object {
           "description": "describes all life",
-          "fields": Array [
-            Object {
-              "name": "uuid",
-              "type": "STRING",
-            },
-            Object {
-              "name": "name",
-              "type": "STRING",
-            },
-            Object {
-              "name": "mass",
-              "type": "INTEGER",
-            },
-            Object {
-              "name": "dimension",
-              "type": "STRING",
-            },
-            Object {
-              "name": "interstellar",
-              "type": "BOOLEAN",
-            },
-          ],
+          "fields": Array [],
           "name": "objects.life",
           "namespace": "galactic-data",
           "physicalName": "objects.life",
@@ -2432,14 +2350,14 @@ exports[`DatasetDetailPage Component when there is a match for the datasetName i
       mt={10}
     >
       <div
-        className="MuiBox-root MuiBox-root-43 DatasetDetailPage-root-1"
+        className="MuiBox-root MuiBox-root-45 DatasetDetailPage-root-1"
       >
         <Styled(MuiBox)
           display="flex"
           justifyContent="space-between"
         >
           <div
-            className="MuiBox-root MuiBox-root-44"
+            className="MuiBox-root MuiBox-root-46"
           >
             <div>
               <WithStyles(ForwardRef(Typography))
@@ -2548,7 +2466,7 @@ exports[`DatasetDetailPage Component when there is a match for the datasetName i
               id="tagContainer"
             >
               <div
-                className="DatasetDetailPage-tagHolder-10"
+                className="DatasetDetailPage-tagHolder-12"
               >
                 <div
                   key="is_pii"
@@ -2767,13 +2685,13 @@ exports[`DatasetDetailPage Component when there is a match for the datasetName i
               </div>
               <WithStyles(ForwardRef(Fab))
                 aria-label="edit"
-                className="DatasetDetailPage-closeButton-9"
+                className="DatasetDetailPage-closeButton-11"
                 onClick={[Function]}
                 size="small"
               >
                 <ForwardRef(Fab)
                   aria-label="edit"
-                  className="DatasetDetailPage-closeButton-9"
+                  className="DatasetDetailPage-closeButton-11"
                   classes={
                     Object {
                       "colorInherit": "MuiFab-colorInherit",
@@ -2793,7 +2711,7 @@ exports[`DatasetDetailPage Component when there is a match for the datasetName i
                 >
                   <WithStyles(ForwardRef(ButtonBase))
                     aria-label="edit"
-                    className="MuiFab-root DatasetDetailPage-closeButton-9 MuiFab-sizeSmall"
+                    className="MuiFab-root DatasetDetailPage-closeButton-11 MuiFab-sizeSmall"
                     component="button"
                     disabled={false}
                     focusRipple={true}
@@ -2802,7 +2720,7 @@ exports[`DatasetDetailPage Component when there is a match for the datasetName i
                   >
                     <ForwardRef(ButtonBase)
                       aria-label="edit"
-                      className="MuiFab-root DatasetDetailPage-closeButton-9 MuiFab-sizeSmall"
+                      className="MuiFab-root DatasetDetailPage-closeButton-11 MuiFab-sizeSmall"
                       classes={
                         Object {
                           "disabled": "Mui-disabled",
@@ -2818,7 +2736,7 @@ exports[`DatasetDetailPage Component when there is a match for the datasetName i
                     >
                       <button
                         aria-label="edit"
-                        className="MuiButtonBase-root MuiFab-root DatasetDetailPage-closeButton-9 MuiFab-sizeSmall"
+                        className="MuiButtonBase-root MuiFab-root DatasetDetailPage-closeButton-11 MuiFab-sizeSmall"
                         disabled={false}
                         onBlur={[Function]}
                         onClick={[Function]}
@@ -2880,10 +2798,10 @@ exports[`DatasetDetailPage Component when there is a match for the datasetName i
           </div>
         </Styled(MuiBox)>
         <WithStyles(ForwardRef(Paper))
-          className="DatasetDetailPage-paper-7"
+          className="DatasetDetailPage-paper-9"
         >
           <ForwardRef(Paper)
-            className="DatasetDetailPage-paper-7"
+            className="DatasetDetailPage-paper-9"
             classes={
               Object {
                 "elevation0": "MuiPaper-elevation0",
@@ -2917,7 +2835,7 @@ exports[`DatasetDetailPage Component when there is a match for the datasetName i
             }
           >
             <div
-              className="MuiPaper-root MuiPaper-elevation1 DatasetDetailPage-paper-7 MuiPaper-rounded"
+              className="MuiPaper-root MuiPaper-elevation1 DatasetDetailPage-paper-9 MuiPaper-rounded"
             >
               <WithStyles(ForwardRef(Table))
                 size="small"
@@ -2946,10 +2864,10 @@ exports[`DatasetDetailPage Component when there is a match for the datasetName i
                           className="MuiTableHead-root"
                         >
                           <WithStyles(ForwardRef(TableRow))
-                            className="DatasetDetailPage-tableRow-6"
+                            className="DatasetDetailPage-tableRow-8"
                           >
                             <ForwardRef(TableRow)
-                              className="DatasetDetailPage-tableRow-6"
+                              className="DatasetDetailPage-tableRow-8"
                               classes={
                                 Object {
                                   "footer": "MuiTableRow-footer",
@@ -2961,16 +2879,16 @@ exports[`DatasetDetailPage Component when there is a match for the datasetName i
                               }
                             >
                               <tr
-                                className="MuiTableRow-root DatasetDetailPage-tableRow-6 MuiTableRow-head"
+                                className="MuiTableRow-root DatasetDetailPage-tableRow-8 MuiTableRow-head"
                               >
                                 <WithStyles(ForwardRef(TableCell))
                                   align="center"
-                                  className="DatasetDetailPage-tableCell-5"
+                                  className="DatasetDetailPage-tableCell-7"
                                   key="uuid"
                                 >
                                   <ForwardRef(TableCell)
                                     align="center"
-                                    className="DatasetDetailPage-tableCell-5"
+                                    className="DatasetDetailPage-tableCell-7"
                                     classes={
                                       Object {
                                         "alignCenter": "MuiTableCell-alignCenter",
@@ -2990,7 +2908,7 @@ exports[`DatasetDetailPage Component when there is a match for the datasetName i
                                   >
                                     <th
                                       aria-sort={null}
-                                      className="MuiTableCell-root MuiTableCell-head DatasetDetailPage-tableCell-5 MuiTableCell-alignCenter MuiTableCell-sizeSmall"
+                                      className="MuiTableCell-root MuiTableCell-head DatasetDetailPage-tableCell-7 MuiTableCell-alignCenter MuiTableCell-sizeSmall"
                                       scope="col"
                                     >
                                       <strong>
@@ -3018,7 +2936,7 @@ exports[`DatasetDetailPage Component when there is a match for the datasetName i
                                         >
                                           <div
                                             aria-describedby={null}
-                                            className="DatasetDetailPage-infoIcon-4"
+                                            className="DatasetDetailPage-infoIcon-6"
                                             onBlur={[Function]}
                                             onFocus={[Function]}
                                             onMouseLeave={[Function]}
@@ -3081,12 +2999,12 @@ exports[`DatasetDetailPage Component when there is a match for the datasetName i
                                 </WithStyles(ForwardRef(TableCell))>
                                 <WithStyles(ForwardRef(TableCell))
                                   align="center"
-                                  className="DatasetDetailPage-tableCell-5"
+                                  className="DatasetDetailPage-tableCell-7"
                                   key="name"
                                 >
                                   <ForwardRef(TableCell)
                                     align="center"
-                                    className="DatasetDetailPage-tableCell-5"
+                                    className="DatasetDetailPage-tableCell-7"
                                     classes={
                                       Object {
                                         "alignCenter": "MuiTableCell-alignCenter",
@@ -3106,7 +3024,7 @@ exports[`DatasetDetailPage Component when there is a match for the datasetName i
                                   >
                                     <th
                                       aria-sort={null}
-                                      className="MuiTableCell-root MuiTableCell-head DatasetDetailPage-tableCell-5 MuiTableCell-alignCenter MuiTableCell-sizeSmall"
+                                      className="MuiTableCell-root MuiTableCell-head DatasetDetailPage-tableCell-7 MuiTableCell-alignCenter MuiTableCell-sizeSmall"
                                       scope="col"
                                     >
                                       <strong>
@@ -3134,7 +3052,7 @@ exports[`DatasetDetailPage Component when there is a match for the datasetName i
                                         >
                                           <div
                                             aria-describedby={null}
-                                            className="DatasetDetailPage-infoIcon-4"
+                                            className="DatasetDetailPage-infoIcon-6"
                                             onBlur={[Function]}
                                             onFocus={[Function]}
                                             onMouseLeave={[Function]}
@@ -3197,12 +3115,12 @@ exports[`DatasetDetailPage Component when there is a match for the datasetName i
                                 </WithStyles(ForwardRef(TableCell))>
                                 <WithStyles(ForwardRef(TableCell))
                                   align="center"
-                                  className="DatasetDetailPage-tableCell-5"
+                                  className="DatasetDetailPage-tableCell-7"
                                   key="mass"
                                 >
                                   <ForwardRef(TableCell)
                                     align="center"
-                                    className="DatasetDetailPage-tableCell-5"
+                                    className="DatasetDetailPage-tableCell-7"
                                     classes={
                                       Object {
                                         "alignCenter": "MuiTableCell-alignCenter",
@@ -3222,7 +3140,7 @@ exports[`DatasetDetailPage Component when there is a match for the datasetName i
                                   >
                                     <th
                                       aria-sort={null}
-                                      className="MuiTableCell-root MuiTableCell-head DatasetDetailPage-tableCell-5 MuiTableCell-alignCenter MuiTableCell-sizeSmall"
+                                      className="MuiTableCell-root MuiTableCell-head DatasetDetailPage-tableCell-7 MuiTableCell-alignCenter MuiTableCell-sizeSmall"
                                       scope="col"
                                     >
                                       <strong>
@@ -3250,7 +3168,7 @@ exports[`DatasetDetailPage Component when there is a match for the datasetName i
                                         >
                                           <div
                                             aria-describedby={null}
-                                            className="DatasetDetailPage-infoIcon-4"
+                                            className="DatasetDetailPage-infoIcon-6"
                                             onBlur={[Function]}
                                             onFocus={[Function]}
                                             onMouseLeave={[Function]}
@@ -3313,12 +3231,12 @@ exports[`DatasetDetailPage Component when there is a match for the datasetName i
                                 </WithStyles(ForwardRef(TableCell))>
                                 <WithStyles(ForwardRef(TableCell))
                                   align="center"
-                                  className="DatasetDetailPage-tableCell-5"
+                                  className="DatasetDetailPage-tableCell-7"
                                   key="dimension"
                                 >
                                   <ForwardRef(TableCell)
                                     align="center"
-                                    className="DatasetDetailPage-tableCell-5"
+                                    className="DatasetDetailPage-tableCell-7"
                                     classes={
                                       Object {
                                         "alignCenter": "MuiTableCell-alignCenter",
@@ -3338,7 +3256,7 @@ exports[`DatasetDetailPage Component when there is a match for the datasetName i
                                   >
                                     <th
                                       aria-sort={null}
-                                      className="MuiTableCell-root MuiTableCell-head DatasetDetailPage-tableCell-5 MuiTableCell-alignCenter MuiTableCell-sizeSmall"
+                                      className="MuiTableCell-root MuiTableCell-head DatasetDetailPage-tableCell-7 MuiTableCell-alignCenter MuiTableCell-sizeSmall"
                                       scope="col"
                                     >
                                       <strong>
@@ -3366,7 +3284,7 @@ exports[`DatasetDetailPage Component when there is a match for the datasetName i
                                         >
                                           <div
                                             aria-describedby={null}
-                                            className="DatasetDetailPage-infoIcon-4"
+                                            className="DatasetDetailPage-infoIcon-6"
                                             onBlur={[Function]}
                                             onFocus={[Function]}
                                             onMouseLeave={[Function]}
@@ -3429,12 +3347,12 @@ exports[`DatasetDetailPage Component when there is a match for the datasetName i
                                 </WithStyles(ForwardRef(TableCell))>
                                 <WithStyles(ForwardRef(TableCell))
                                   align="center"
-                                  className="DatasetDetailPage-tableCell-5"
+                                  className="DatasetDetailPage-tableCell-7"
                                   key="interstellar"
                                 >
                                   <ForwardRef(TableCell)
                                     align="center"
-                                    className="DatasetDetailPage-tableCell-5"
+                                    className="DatasetDetailPage-tableCell-7"
                                     classes={
                                       Object {
                                         "alignCenter": "MuiTableCell-alignCenter",
@@ -3454,7 +3372,7 @@ exports[`DatasetDetailPage Component when there is a match for the datasetName i
                                   >
                                     <th
                                       aria-sort={null}
-                                      className="MuiTableCell-root MuiTableCell-head DatasetDetailPage-tableCell-5 MuiTableCell-alignCenter MuiTableCell-sizeSmall"
+                                      className="MuiTableCell-root MuiTableCell-head DatasetDetailPage-tableCell-7 MuiTableCell-alignCenter MuiTableCell-sizeSmall"
                                       scope="col"
                                     >
                                       <strong>
@@ -3482,7 +3400,7 @@ exports[`DatasetDetailPage Component when there is a match for the datasetName i
                                         >
                                           <div
                                             aria-describedby={null}
-                                            className="DatasetDetailPage-infoIcon-4"
+                                            className="DatasetDetailPage-infoIcon-6"
                                             onBlur={[Function]}
                                             onFocus={[Function]}
                                             onMouseLeave={[Function]}
@@ -3561,10 +3479,10 @@ exports[`DatasetDetailPage Component when there is a match for the datasetName i
                           className="MuiTableBody-root"
                         >
                           <WithStyles(ForwardRef(TableRow))
-                            className="DatasetDetailPage-tableRow-6"
+                            className="DatasetDetailPage-tableRow-8"
                           >
                             <ForwardRef(TableRow)
-                              className="DatasetDetailPage-tableRow-6"
+                              className="DatasetDetailPage-tableRow-8"
                               classes={
                                 Object {
                                   "footer": "MuiTableRow-footer",
@@ -3576,16 +3494,16 @@ exports[`DatasetDetailPage Component when there is a match for the datasetName i
                               }
                             >
                               <tr
-                                className="MuiTableRow-root DatasetDetailPage-tableRow-6"
+                                className="MuiTableRow-root DatasetDetailPage-tableRow-8"
                               >
                                 <WithStyles(ForwardRef(TableCell))
                                   align="left"
-                                  className="DatasetDetailPage-tableCell-5"
+                                  className="DatasetDetailPage-tableCell-7"
                                   key="uuid"
                                 >
                                   <ForwardRef(TableCell)
                                     align="left"
-                                    className="DatasetDetailPage-tableCell-5"
+                                    className="DatasetDetailPage-tableCell-7"
                                     classes={
                                       Object {
                                         "alignCenter": "MuiTableCell-alignCenter",
@@ -3605,7 +3523,7 @@ exports[`DatasetDetailPage Component when there is a match for the datasetName i
                                   >
                                     <td
                                       aria-sort={null}
-                                      className="MuiTableCell-root MuiTableCell-body DatasetDetailPage-tableCell-5 MuiTableCell-alignLeft MuiTableCell-sizeSmall"
+                                      className="MuiTableCell-root MuiTableCell-body DatasetDetailPage-tableCell-7 MuiTableCell-alignLeft MuiTableCell-sizeSmall"
                                     >
                                       no description
                                     </td>
@@ -3613,12 +3531,12 @@ exports[`DatasetDetailPage Component when there is a match for the datasetName i
                                 </WithStyles(ForwardRef(TableCell))>
                                 <WithStyles(ForwardRef(TableCell))
                                   align="left"
-                                  className="DatasetDetailPage-tableCell-5"
+                                  className="DatasetDetailPage-tableCell-7"
                                   key="name"
                                 >
                                   <ForwardRef(TableCell)
                                     align="left"
-                                    className="DatasetDetailPage-tableCell-5"
+                                    className="DatasetDetailPage-tableCell-7"
                                     classes={
                                       Object {
                                         "alignCenter": "MuiTableCell-alignCenter",
@@ -3638,7 +3556,7 @@ exports[`DatasetDetailPage Component when there is a match for the datasetName i
                                   >
                                     <td
                                       aria-sort={null}
-                                      className="MuiTableCell-root MuiTableCell-body DatasetDetailPage-tableCell-5 MuiTableCell-alignLeft MuiTableCell-sizeSmall"
+                                      className="MuiTableCell-root MuiTableCell-body DatasetDetailPage-tableCell-7 MuiTableCell-alignLeft MuiTableCell-sizeSmall"
                                     >
                                       no description
                                     </td>
@@ -3646,12 +3564,12 @@ exports[`DatasetDetailPage Component when there is a match for the datasetName i
                                 </WithStyles(ForwardRef(TableCell))>
                                 <WithStyles(ForwardRef(TableCell))
                                   align="left"
-                                  className="DatasetDetailPage-tableCell-5"
+                                  className="DatasetDetailPage-tableCell-7"
                                   key="mass"
                                 >
                                   <ForwardRef(TableCell)
                                     align="left"
-                                    className="DatasetDetailPage-tableCell-5"
+                                    className="DatasetDetailPage-tableCell-7"
                                     classes={
                                       Object {
                                         "alignCenter": "MuiTableCell-alignCenter",
@@ -3671,7 +3589,7 @@ exports[`DatasetDetailPage Component when there is a match for the datasetName i
                                   >
                                     <td
                                       aria-sort={null}
-                                      className="MuiTableCell-root MuiTableCell-body DatasetDetailPage-tableCell-5 MuiTableCell-alignLeft MuiTableCell-sizeSmall"
+                                      className="MuiTableCell-root MuiTableCell-body DatasetDetailPage-tableCell-7 MuiTableCell-alignLeft MuiTableCell-sizeSmall"
                                     >
                                       no description
                                     </td>
@@ -3679,12 +3597,12 @@ exports[`DatasetDetailPage Component when there is a match for the datasetName i
                                 </WithStyles(ForwardRef(TableCell))>
                                 <WithStyles(ForwardRef(TableCell))
                                   align="left"
-                                  className="DatasetDetailPage-tableCell-5"
+                                  className="DatasetDetailPage-tableCell-7"
                                   key="dimension"
                                 >
                                   <ForwardRef(TableCell)
                                     align="left"
-                                    className="DatasetDetailPage-tableCell-5"
+                                    className="DatasetDetailPage-tableCell-7"
                                     classes={
                                       Object {
                                         "alignCenter": "MuiTableCell-alignCenter",
@@ -3704,7 +3622,7 @@ exports[`DatasetDetailPage Component when there is a match for the datasetName i
                                   >
                                     <td
                                       aria-sort={null}
-                                      className="MuiTableCell-root MuiTableCell-body DatasetDetailPage-tableCell-5 MuiTableCell-alignLeft MuiTableCell-sizeSmall"
+                                      className="MuiTableCell-root MuiTableCell-body DatasetDetailPage-tableCell-7 MuiTableCell-alignLeft MuiTableCell-sizeSmall"
                                     >
                                       no description
                                     </td>
@@ -3712,12 +3630,12 @@ exports[`DatasetDetailPage Component when there is a match for the datasetName i
                                 </WithStyles(ForwardRef(TableCell))>
                                 <WithStyles(ForwardRef(TableCell))
                                   align="left"
-                                  className="DatasetDetailPage-tableCell-5"
+                                  className="DatasetDetailPage-tableCell-7"
                                   key="interstellar"
                                 >
                                   <ForwardRef(TableCell)
                                     align="left"
-                                    className="DatasetDetailPage-tableCell-5"
+                                    className="DatasetDetailPage-tableCell-7"
                                     classes={
                                       Object {
                                         "alignCenter": "MuiTableCell-alignCenter",
@@ -3737,7 +3655,7 @@ exports[`DatasetDetailPage Component when there is a match for the datasetName i
                                   >
                                     <td
                                       aria-sort={null}
-                                      className="MuiTableCell-root MuiTableCell-body DatasetDetailPage-tableCell-5 MuiTableCell-alignLeft MuiTableCell-sizeSmall"
+                                      className="MuiTableCell-root MuiTableCell-body DatasetDetailPage-tableCell-7 MuiTableCell-alignLeft MuiTableCell-sizeSmall"
                                     >
                                       no description
                                     </td>
@@ -3757,12 +3675,12 @@ exports[`DatasetDetailPage Component when there is a match for the datasetName i
         </WithStyles(ForwardRef(Paper))>
         <WithStyles(ForwardRef(Typography))
           align="right"
-          className="DatasetDetailPage-updated-8"
+          className="DatasetDetailPage-updated-10"
           color="primary"
         >
           <ForwardRef(Typography)
             align="right"
-            className="DatasetDetailPage-updated-8"
+            className="DatasetDetailPage-updated-10"
             classes={
               Object {
                 "alignCenter": "MuiTypography-alignCenter",
@@ -3800,7 +3718,7 @@ exports[`DatasetDetailPage Component when there is a match for the datasetName i
             color="primary"
           >
             <p
-              className="MuiTypography-root DatasetDetailPage-updated-8 MuiTypography-body1 MuiTypography-colorPrimary MuiTypography-alignRight"
+              className="MuiTypography-root DatasetDetailPage-updated-10 MuiTypography-body1 MuiTypography-colorPrimary MuiTypography-alignRight"
             >
               last updated: 
             </p>
@@ -3878,28 +3796,7 @@ exports[`DatasetDetailPage Component when there is no match for the datasetName 
       },
       Object {
         "description": "all trips taken through the galaxy",
-        "fields": Array [
-          Object {
-            "name": "uuid",
-            "type": "STRING",
-          },
-          Object {
-            "name": "name",
-            "type": "STRING",
-          },
-          Object {
-            "name": "mass",
-            "type": "INTEGER",
-          },
-          Object {
-            "name": "dimension",
-            "type": "STRING",
-          },
-          Object {
-            "name": "interstellar",
-            "type": "BOOLEAN",
-          },
-        ],
+        "fields": Array [],
         "name": "galaxy.trips",
         "namespace": "galactic-data",
         "physicalName": "galaxy.trips",
@@ -4028,28 +3925,7 @@ exports[`DatasetDetailPage Component when there is no match for the datasetName 
       },
       Object {
         "description": "describes all life",
-        "fields": Array [
-          Object {
-            "name": "uuid",
-            "type": "STRING",
-          },
-          Object {
-            "name": "name",
-            "type": "STRING",
-          },
-          Object {
-            "name": "mass",
-            "type": "INTEGER",
-          },
-          Object {
-            "name": "dimension",
-            "type": "STRING",
-          },
-          Object {
-            "name": "interstellar",
-            "type": "BOOLEAN",
-          },
-        ],
+        "fields": Array [],
         "name": "objects.life",
         "namespace": "galactic-data",
         "physicalName": "objects.life",
@@ -5022,16 +4898,18 @@ exports[`DatasetDetailPage Component when there is no match for the datasetName 
   <DatasetDetailPage
     classes={
       Object {
-        "closeButton": "DatasetDetailPage-closeButton-9",
-        "infoIcon": "DatasetDetailPage-infoIcon-4",
+        "closeButton": "DatasetDetailPage-closeButton-11",
+        "infoIcon": "DatasetDetailPage-infoIcon-6",
         "noData": "DatasetDetailPage-noData-3",
-        "paper": "DatasetDetailPage-paper-7",
+        "noSchema": "DatasetDetailPage-noSchema-4",
+        "noSchemaTitle": "DatasetDetailPage-noSchemaTitle-5",
+        "paper": "DatasetDetailPage-paper-9",
         "root": "DatasetDetailPage-root-1",
-        "tableCell": "DatasetDetailPage-tableCell-5",
-        "tableRow": "DatasetDetailPage-tableRow-6",
+        "tableCell": "DatasetDetailPage-tableCell-7",
+        "tableRow": "DatasetDetailPage-tableRow-8",
         "tagContainer": "DatasetDetailPage-tagContainer-2",
-        "tagHolder": "DatasetDetailPage-tagHolder-10",
-        "updated": "DatasetDetailPage-updated-8",
+        "tagHolder": "DatasetDetailPage-tagHolder-12",
+        "updated": "DatasetDetailPage-updated-10",
       }
     }
     datasets={
@@ -5098,28 +4976,7 @@ exports[`DatasetDetailPage Component when there is no match for the datasetName 
         },
         Object {
           "description": "all trips taken through the galaxy",
-          "fields": Array [
-            Object {
-              "name": "uuid",
-              "type": "STRING",
-            },
-            Object {
-              "name": "name",
-              "type": "STRING",
-            },
-            Object {
-              "name": "mass",
-              "type": "INTEGER",
-            },
-            Object {
-              "name": "dimension",
-              "type": "STRING",
-            },
-            Object {
-              "name": "interstellar",
-              "type": "BOOLEAN",
-            },
-          ],
+          "fields": Array [],
           "name": "galaxy.trips",
           "namespace": "galactic-data",
           "physicalName": "galaxy.trips",
@@ -5248,28 +5105,7 @@ exports[`DatasetDetailPage Component when there is no match for the datasetName 
         },
         Object {
           "description": "describes all life",
-          "fields": Array [
-            Object {
-              "name": "uuid",
-              "type": "STRING",
-            },
-            Object {
-              "name": "name",
-              "type": "STRING",
-            },
-            Object {
-              "name": "mass",
-              "type": "INTEGER",
-            },
-            Object {
-              "name": "dimension",
-              "type": "STRING",
-            },
-            Object {
-              "name": "interstellar",
-              "type": "BOOLEAN",
-            },
-          ],
+          "fields": Array [],
           "name": "objects.life",
           "namespace": "galactic-data",
           "physicalName": "objects.life",
@@ -6246,7 +6082,7 @@ exports[`DatasetDetailPage Component when there is no match for the datasetName 
       mt={10}
     >
       <div
-        className="MuiBox-root MuiBox-root-12 DatasetDetailPage-root-1"
+        className="MuiBox-root MuiBox-root-14 DatasetDetailPage-root-1"
       >
         <WithStyles(ForwardRef(Typography))
           align="center"

--- a/src/__tests__/components/__snapshots__/DatasetDetailPage.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/DatasetDetailPage.test.tsx.snap
@@ -204,28 +204,6 @@ exports[`DatasetDetailPage Component when there is a match for the datasetName i
       },
       Object {
         "description": "describes the entire universe",
-        "fields": Array [
-          Object {
-            "name": "uuid",
-            "type": "STRING",
-          },
-          Object {
-            "name": "name",
-            "type": "STRING",
-          },
-          Object {
-            "name": "mass",
-            "type": "INTEGER",
-          },
-          Object {
-            "name": "dimension",
-            "type": "STRING",
-          },
-          Object {
-            "name": "interstellar",
-            "type": "BOOLEAN",
-          },
-        ],
         "name": "environment.universe",
         "namespace": "galactic-data",
         "physicalName": "environment.universe",
@@ -1384,28 +1362,6 @@ exports[`DatasetDetailPage Component when there is a match for the datasetName i
         },
         Object {
           "description": "describes the entire universe",
-          "fields": Array [
-            Object {
-              "name": "uuid",
-              "type": "STRING",
-            },
-            Object {
-              "name": "name",
-              "type": "STRING",
-            },
-            Object {
-              "name": "mass",
-              "type": "INTEGER",
-            },
-            Object {
-              "name": "dimension",
-              "type": "STRING",
-            },
-            Object {
-              "name": "interstellar",
-              "type": "BOOLEAN",
-            },
-          ],
           "name": "environment.universe",
           "namespace": "galactic-data",
           "physicalName": "environment.universe",
@@ -3934,28 +3890,6 @@ exports[`DatasetDetailPage Component when there is no match for the datasetName 
       },
       Object {
         "description": "describes the entire universe",
-        "fields": Array [
-          Object {
-            "name": "uuid",
-            "type": "STRING",
-          },
-          Object {
-            "name": "name",
-            "type": "STRING",
-          },
-          Object {
-            "name": "mass",
-            "type": "INTEGER",
-          },
-          Object {
-            "name": "dimension",
-            "type": "STRING",
-          },
-          Object {
-            "name": "interstellar",
-            "type": "BOOLEAN",
-          },
-        ],
         "name": "environment.universe",
         "namespace": "galactic-data",
         "physicalName": "environment.universe",
@@ -5114,28 +5048,6 @@ exports[`DatasetDetailPage Component when there is no match for the datasetName 
         },
         Object {
           "description": "describes the entire universe",
-          "fields": Array [
-            Object {
-              "name": "uuid",
-              "type": "STRING",
-            },
-            Object {
-              "name": "name",
-              "type": "STRING",
-            },
-            Object {
-              "name": "mass",
-              "type": "INTEGER",
-            },
-            Object {
-              "name": "dimension",
-              "type": "STRING",
-            },
-            Object {
-              "name": "interstellar",
-              "type": "BOOLEAN",
-            },
-          ],
           "name": "environment.universe",
           "namespace": "galactic-data",
           "physicalName": "environment.universe",

--- a/src/components/DatasetDetailPage.tsx
+++ b/src/components/DatasetDetailPage.tsx
@@ -2,7 +2,8 @@ import React, { FunctionComponent } from 'react'
 import {
   withStyles,
   createStyles,
-  WithStyles as IWithStyles
+  WithStyles as IWithStyles,
+  Theme as ITheme
 } from '@material-ui/core/styles'
 import { Typography, Box, Tooltip, Fab, Table, TableCell, TableHead, TableRow, TableBody, Paper } from '@material-ui/core'
 
@@ -19,7 +20,7 @@ import _keys from 'lodash/keys'
 
 import { IDataset } from '../types'
 
-const styles = () => {
+const styles = ({ shadows }: ITheme) => {
   return createStyles({
     root: {
       marginTop: '52vh',
@@ -32,6 +33,13 @@ const styles = () => {
     },
     noData: {
       padding: '125px 0 0 0'
+    },
+    noSchema: {
+      boxShadow: shadows[1],
+      padding: '1rem'
+    },
+    noSchemaTitle: {
+      fontSize: '14px'
     },
     infoIcon: {
       paddingLeft: '3px',
@@ -73,7 +81,7 @@ type IProps = IWithStyles<typeof styles> & { datasets: IDataset[] }
 const DatasetDetailPage: FunctionComponent<IProps> = props => {
   const { datasets, classes } = props
   const {
-    root, paper, updated, tagContainer, noData, infoIcon, tableCell, tableRow, closeButton, tagHolder
+    root, paper, updated, tagContainer, noData, noSchema, noSchemaTitle, infoIcon, tableCell, tableRow, closeButton, tagHolder
   } = classes
   const { datasetName } = useParams()
   const history = useHistory()
@@ -128,34 +136,42 @@ const DatasetDetailPage: FunctionComponent<IProps> = props => {
             </Fab>
           </div>
         </Box>
-        <Paper className={paper}>
-          <Table size="small">
-            <TableHead>
-              <TableRow className={tableRow}>
-                {
-                  fields.map((field) => {
-                    return (
-                    <TableCell className={tableCell} key={field.name} align="center"><strong>{field.name}</strong>
-                      <Tooltip title={field.type} placement="top">
-                        <div className={infoIcon}>
-                          <InfoIcon color='disabled' fontSize='small' />
-                        </div>
-                      </Tooltip>
-                    </TableCell>
-                    )
-                  })
-                }
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              <TableRow className={tableRow}>
-                {fields.map((field) => {
-                  return <TableCell className={tableCell} key={field.name} align="left">{field.description || 'no description'}</TableCell>
-                })}
-              </TableRow>
-            </TableBody>
-          </Table>
-        </Paper>
+        {fields.length > 0 ? (
+          <Paper className={paper}>
+            <Table size="small">
+              <TableHead>
+                <TableRow className={tableRow}>
+                  {
+                    fields.map((field) => {
+                      return (
+                      <TableCell className={tableCell} key={field.name} align="center"><strong>{field.name}</strong>
+                        <Tooltip title={field.type} placement="top">
+                          <div className={infoIcon}>
+                            <InfoIcon color='disabled' fontSize='small' />
+                          </div>
+                        </Tooltip>
+                      </TableCell>
+                      )
+                    })
+                  }
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                <TableRow className={tableRow}>
+                  {fields.map((field) => {
+                    return <TableCell className={tableCell} key={field.name} align="left">{field.description || 'no description'}</TableCell>
+                  })}
+                </TableRow>
+              </TableBody>
+            </Table>
+          </Paper>
+        ) : (
+          <div className={noSchema}>
+            <Typography className={noSchemaTitle}>
+              schema not present
+            </Typography>
+          </div>
+        )}
         <Typography className={updated} color='primary' align='right'>
           last updated: {formatUpdatedAt(updatedAt)}
         </Typography>

--- a/src/components/DatasetDetailPage.tsx
+++ b/src/components/DatasetDetailPage.tsx
@@ -136,7 +136,7 @@ const DatasetDetailPage: FunctionComponent<IProps> = props => {
             </Fab>
           </div>
         </Box>
-        {fields.length > 0 ? (
+        {fields && fields.length > 0 ? (
           <Paper className={paper}>
             <Table size="small">
               <TableHead>

--- a/src/components/JobDetailPage.tsx
+++ b/src/components/JobDetailPage.tsx
@@ -187,7 +187,7 @@ const displaySQL = (SQL: string, SQLCommentClass: string) => {
 const JobDetailPage: FunctionComponent<IProps> = props => {
   const { jobs, classes, fetchJobRuns } = props
   const [SQLModalOpen, setSQLModalOpen] = useState(false)
-  
+
   const { jobName } = useParams()
   const history = useHistory()
 


### PR DESCRIPTION
This PR addresses [issue 50](https://github.com/MarquezProject/marquez-web/issues/50) and inserts a message saying a schema isn't present if there are no fields or if the fields array is empty

It also updates the dummy data to account for these scenarios. The datasets updated are (environment.universe, galaxy.trips, objects.life)

<img width="1060" alt="Screen Shot 2020-01-23 at 4 17 59 PM" src="https://user-images.githubusercontent.com/1332789/73025401-87a55100-3dfd-11ea-872b-fef56da1cb45.png">
