### PR TITLE
update nodes in the graph with a link to the detail page

### DIFF
--- a/src/components/NetworkGraph.tsx
+++ b/src/components/NetworkGraph.tsx
@@ -1,6 +1,9 @@
 import * as React from 'react'
 import * as d3 from 'd3'
 import {
+  Link
+} from 'react-router-dom'
+import {
   withStyles,
   createStyles,
   WithStyles as IWithStyles,
@@ -127,11 +130,14 @@ export class NetworkGraph extends React.Component<IAllProps, {}> {
       .join(
         enter =>
           enter
+            .append("a")
+            .attr("href", d => ("/jobs/" + d.id))
             .append('circle')
             .attr('class', 'jobNode')
             .attr('r', 5)
             .attr('fill', n => (n.matches ? jobNodeGrey : fadedOut)),
-        update => update.attr('fill', n => (n.matches ? jobNodeGrey : fadedOut)),
+        update => update
+          .attr('fill', n => (n.matches ? jobNodeGrey : fadedOut)),
         exit => exit.remove()
       )
 
@@ -151,6 +157,8 @@ export class NetworkGraph extends React.Component<IAllProps, {}> {
       .join(
         enter =>
           enter
+            .append("a")
+            .attr("href", d => ("/datasets/" + d.id))
             .append('rect')
             .attr('class', 'datasetNode')
             .attr('width', datasetNodeDimension)

--- a/src/components/NetworkGraph.tsx
+++ b/src/components/NetworkGraph.tsx
@@ -1,9 +1,6 @@
 import * as React from 'react'
 import * as d3 from 'd3'
 import {
-  Link
-} from 'react-router-dom'
-import {
   withStyles,
   createStyles,
   WithStyles as IWithStyles,
@@ -130,8 +127,8 @@ export class NetworkGraph extends React.Component<IAllProps, {}> {
       .join(
         enter =>
           enter
-            .append("a")
-            .attr("href", d => ("/jobs/" + d.id))
+            .append('a')
+            .attr('href', d => ('/jobs/' + d.id))
             .append('circle')
             .attr('class', 'jobNode')
             .attr('r', 5)
@@ -157,8 +154,8 @@ export class NetworkGraph extends React.Component<IAllProps, {}> {
       .join(
         enter =>
           enter
-            .append("a")
-            .attr("href", d => ("/datasets/" + d.id))
+            .append('a')
+            .attr('href', d => ('/datasets/' + d.id))
             .append('rect')
             .attr('class', 'datasetNode')
             .attr('width', datasetNodeDimension)


### PR DESCRIPTION
Adds a link from the nodes in the lineage graph to the respective dataset or job detail page
This resolves [issue 61](https://github.com/MarquezProject/marquez-web/issues/61).