### PR TITLE
feature/lineage-detail

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -93,7 +93,7 @@ const App = ({ classes }: IProps): ReactElement => {
           <CssBaseline />
           <Grid direction='column' alignItems='stretch' classes={classes} justify='space-between'>
             <AppBar />
-            <NetworkGraphContainer history={history}/>
+            <NetworkGraphContainer />
             <CustomSearchBarContainer
               setShowJobs={setShowJobs}
               showJobs={showJobs}

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -83,7 +83,6 @@ const TITLE = 'Marquez | Data Kit'
 
 const App = ({ classes }: IProps): ReactElement => {
   const [showJobs, setShowJobs] = useState(false)
-
   return (
     <Provider store={store}>
       <ConnectedRouter history={history}>
@@ -94,7 +93,7 @@ const App = ({ classes }: IProps): ReactElement => {
           <CssBaseline />
           <Grid direction='column' alignItems='stretch' classes={classes} justify='space-between'>
             <AppBar />
-            <NetworkGraphContainer />
+            <NetworkGraphContainer history={history}/>
             <CustomSearchBarContainer
               setShowJobs={setShowJobs}
               showJobs={showJobs}

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -83,6 +83,7 @@ const TITLE = 'Marquez | Data Kit'
 
 const App = ({ classes }: IProps): ReactElement => {
   const [showJobs, setShowJobs] = useState(false)
+
   return (
     <Provider store={store}>
       <ConnectedRouter history={history}>

--- a/src/components/NetworkGraph.tsx
+++ b/src/components/NetworkGraph.tsx
@@ -65,12 +65,15 @@ interface IProps {
   jobs: IJob[]
   datasets: IDataset[]
   isLoading: boolean
+  history: any
 }
 
 type IAllProps = IWithStyles<typeof styles> & IProps
 
 export class NetworkGraph extends React.Component<IAllProps, {}> {
   shouldComponentUpdate(newProps: IProps) {
+    const { history } = newProps
+    console.log('History: ', history)
 
     const svg: d3.Selection<SVGElement, void, HTMLElement, void> = select('#network-graph')
 

--- a/src/components/NetworkGraph.tsx
+++ b/src/components/NetworkGraph.tsx
@@ -71,14 +71,12 @@ type IAllProps = IWithStyles<typeof styles> & IProps
 
 export class NetworkGraph extends React.Component<IAllProps, {}> {
   shouldComponentUpdate(newProps: IProps) {
-    
+
     const svg: d3.Selection<SVGElement, void, HTMLElement, void> = select('#network-graph')
 
     if (svg.empty()) {
       return true
     }
-
-    // const width = +svg.style('width').replace('px', '')
     const height = +svg.style('height').replace('px', '')
 
     const isDataset = (node: any) => {
@@ -283,5 +281,5 @@ export class NetworkGraph extends React.Component<IAllProps, {}> {
     )
   }
 }
-
-export default withStyles(styles)(NetworkGraph)
+ 
+export default (withStyles(styles)(NetworkGraph))

--- a/src/components/NetworkGraph.tsx
+++ b/src/components/NetworkGraph.tsx
@@ -65,15 +65,15 @@ interface IProps {
   jobs: IJob[]
   datasets: IDataset[]
   isLoading: boolean
-  history: any
+  router: any
 }
 
 type IAllProps = IWithStyles<typeof styles> & IProps
 
 export class NetworkGraph extends React.Component<IAllProps, {}> {
   shouldComponentUpdate(newProps: IProps) {
-    const { history } = newProps
-    console.log('History: ', history)
+    const urlBreakdown = newProps.router.location.pathname.split('/')
+    const nodeId = urlBreakdown[2]
 
     const svg: d3.Selection<SVGElement, void, HTMLElement, void> = select('#network-graph')
 
@@ -236,7 +236,8 @@ export class NetworkGraph extends React.Component<IAllProps, {}> {
     }
     
     // run calculations for network graph
-    const lineages = getLineages()
+    let lineages = getLineages()
+    lineages = nodeId ? [_find(lineages, lineage => lineage.name == nodeId)] : lineages
     let clusters = _map(lineages, lineage => hierarchy(lineage))
     clusters = _sortBy(clusters, l => l.descendants().length)
     const largestCluster = clusters[clusters.length - 1]

--- a/src/containers/NetworkGraphContainer.tsx
+++ b/src/containers/NetworkGraphContainer.tsx
@@ -8,7 +8,8 @@ import { IState } from '../reducers'
 const mapStateToProps = (state: IState) => ({
   datasets: state.datasets,
   jobs: state.jobs,
-  isLoading: state.display.isLoading
+  isLoading: state.display.isLoading,
+  router: state.router
 })
 
 const mapDispatchToProps = (dispatch: Redux.Dispatch) => ({

--- a/src/containers/NetworkGraphContainer.tsx
+++ b/src/containers/NetworkGraphContainer.tsx
@@ -4,6 +4,7 @@ import { bindActionCreators } from 'redux'
 import NetworkGraph from '../components/NetworkGraph'
 import { IState } from '../reducers'
 
+
 const mapStateToProps = (state: IState) => ({
   datasets: state.datasets,
   jobs: state.jobs,

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -12,6 +12,7 @@ export interface IState {
   jobs: IJobsState
   namespaces: INamespacesState
   display: IDisplayState
+  router: any
 }
 
 export default (history: History): Reducer =>


### PR DESCRIPTION
### Description

This PR makes the lineage respond to the route.  If a detail page is visible, the lineage will be drawn from the respective node.  Otherwise, the largest lineage is displayed (soon to be based on parameters such as most popular dataset)

![lineage-responsiveness](https://user-images.githubusercontent.com/18288572/77949597-369a5900-7295-11ea-8dbe-680edb8f38f0.gif)

