### PR TITLE
Add docker/up.sh

### DIFF
--- a/docker/up.sh
+++ b/docker/up.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Usage: $ ./up.sh
+
+set -e
+
+# Change working directory to project root
+project_root=$(git rev-parse --show-toplevel)
+cd "${project_root}"
+
+docker-compose up -V --force-recreate --build


### PR DESCRIPTION
This PR adds `docker/up.sh` that will:

- Recreate anonymous volumes instead of retrieving
- Force recreate docker containers
- Build images before starting containers

### Usage

```bash
$ ./docker/up.sh
```

Fixes #84 
