### PR TITLE
fixes #90; blank screen caused by null lookup

### DIFF
--- a/src/components/NetworkGraph.tsx
+++ b/src/components/NetworkGraph.tsx
@@ -162,6 +162,7 @@ export class NetworkGraph extends React.Component<IAllProps, {}> {
     const strokeWidth = 5
 
     function findJobColor(job: any) {
+      if (!job.data.latestRun) return circleHighlight
       const key = job.data.latestRun.runState as IJobRunAPI['runState']
       const color = colorMap[key]
       return color


### PR DESCRIPTION
### Description
Fixes #90 caused caused by latestRun being null when no job runs have been added. Defaulted to circleHighlight as this is what was used before #77 introduced this issue

Fix demoed with quick-start data (to reproduce the issue just stop where the guide says to add a job run)
<img width="1131" alt="Screen Shot 2020-04-27 at 11 05 38 PM" src="https://user-images.githubusercontent.com/5345624/80454401-d5d75e00-88de-11ea-83bd-4001799e3ae5.png">
