### PR TITLE
Adds menu item for API Docs

### DIFF
--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -20,6 +20,11 @@ export default function SimpleMenu() {
     const link = __FEEDBACK_FORM_URL__
     window.open(link, '_blank')
   }
+  const apiDocsClicked = () => {
+    handleClose()
+    const link = __API_DOCS_URL__
+    window.open(link, '_blank')
+  }
 
   return (
     <div>
@@ -34,6 +39,7 @@ export default function SimpleMenu() {
         onClose={handleClose}
       >
         <MenuItem onClick={feedBackClicked}>Feedback</MenuItem>
+        <MenuItem onClick={apiDocsClicked}>API Docs</MenuItem>
       </Menu>
     </div>
   )

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -15,3 +15,4 @@ declare const Rollbar: {
 }
 
 declare const __FEEDBACK_FORM_URL__: string
+declare const __API_DOCS_URL__: string

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -31,7 +31,8 @@ const webpackDev = {
       __API_URL__: JSON.stringify('/api/v1'),
       __NODE_ENV__: JSON.stringify('development'),
       __TEMP_ACTOR_STR__: JSON.stringify('me'),
-      __FEEDBACK_FORM_URL__: JSON.stringify('https://forms.gle/f3tTSrZ8wPj3sHTA7')
+      __FEEDBACK_FORM_URL__: JSON.stringify('https://forms.gle/f3tTSrZ8wPj3sHTA7'),
+      __API_DOCS_URL__: JSON.stringify('https://marquezproject.github.io/marquez/openapi.html')
     })
   ]
 }

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -24,7 +24,8 @@ const webpackProd = {
       __API_URL__: JSON.stringify('/api/v1'),
       __TEMP_ACTOR_STR__: JSON.stringify('me'),
       __ROLLBAR__: JSON.stringify(true),
-      __FEEDBACK_FORM_URL__: JSON.stringify('https://forms.gle/f3tTSrZ8wPj3sHTA7')
+      __FEEDBACK_FORM_URL__: JSON.stringify('https://forms.gle/f3tTSrZ8wPj3sHTA7'),
+      __API_DOCS_URL__: JSON.stringify('https://marquezproject.github.io/marquez/openapi.html')
     })
     //new BundleAnalyzerPlugin(),
   ]


### PR DESCRIPTION
### Description

marquez-web currently does not link to the API Documentation.  As an end user of the Marquez ecosystem it would be nice to have my marquez-web instance link to the documentation to make it more discoverable to my users of marquez.

Previously:
![Screen Shot 2020-04-29 at 10 43 30 AM](https://user-images.githubusercontent.com/6012231/80609601-4a58ec80-8a06-11ea-9169-8d5317811ed0.png)


With changes:
![Screen Shot 2020-04-29 at 10 42 16 AM](https://user-images.githubusercontent.com/6012231/80609561-3c0ad080-8a06-11ea-8549-35d442a56b36.png)


### Checklist

- [ ] This PR contains tests (at least one (non-snapshot) test)
