### PR TITLE
Searches for key in all upper case

### DIFF
--- a/src/components/DatasetDetailPage.tsx
+++ b/src/components/DatasetDetailPage.tsx
@@ -125,7 +125,7 @@ const DatasetDetailPage: FunctionComponent<IProps> = props => {
                 return (
                   <div key={key}>
                     <Tooltip className="tagWrapper" title={key} placement="top">
-                      {tags.includes(key) ? tagToBadge.highlighted[key] : tagToBadge.default[key]}
+                      {tags.includes(key.toUpperCase()) ? tagToBadge.highlighted[key] : tagToBadge.default[key]}
                     </Tooltip>
                   </div>
                 )

--- a/src/components/DatasetPreviewCard.tsx
+++ b/src/components/DatasetPreviewCard.tsx
@@ -69,7 +69,7 @@ class DatasetPreviewCard extends React.Component<IProps, IState> {
                 return (
                   <div key={key}>
                     <Tooltip className="tagWrapper" title={key} placement="top">
-                      {tags.includes(key) ? tagToBadge.highlighted[key] : tagToBadge.default[key]}
+                      {tags.includes(key.toUpperCase()) ? tagToBadge.highlighted[key] : tagToBadge.default[key]}
                     </Tooltip>
                   </div>
                 )


### PR DESCRIPTION
### Description

Tags are stored in all upper case https://github.com/MarquezProject/marquez/blob/6703d22be0833e5be9217e885e951876f4f13f40/src/main/java/marquez/service/models/Tag.java#L30 , thus it will be impossible for tags to ever be equal to a set of keys of `["is_pii", "is_compliant"]` unless the values from the API are set to all lower or the keys are set to all upper case

works on #96 

### Checklist

Consider this image

<img width="1623" alt="Screen Shot 2020-05-06 at 3 24 59 PM" src="https://user-images.githubusercontent.com/6012231/81219854-66ccca00-8fae-11ea-8391-37a96c22b82d.png">
