### PR TITLE
Add /healthcheck

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,4 @@
+version: "3.7"
+services:
+  marquez_web:
+    build: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 services:
   marquez_web:
-    build: .
+    image: marquezproject/marquez-web:latest
     environment:
       - MARQUEZ_HOST=marquez
       - MARQUEZ_PORT=5000
@@ -44,7 +44,7 @@ services:
     entrypoint: ["./wait-for-it.sh", "marquez_db:5432", "--", "./entrypoint.sh"]
 
   marquez_db:
-    image: "postgres:9.6"
+    image: postgres:9.6
     ports:
       - "5432:5432"
     environment:

--- a/docker/up.sh
+++ b/docker/up.sh
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Usage: $ ./up.sh
+# Usage: $ ./up.sh [--local]
 
 set -e
 
@@ -20,4 +20,10 @@ set -e
 project_root=$(git rev-parse --show-toplevel)
 cd "${project_root}"
 
-docker-compose up -V --force-recreate --build
+files="-f docker-compose.yml"
+
+if [ "${1}" = "--local" ]; then
+  files+=" -f docker-compose.local.yml"
+fi
+
+docker-compose down && docker-compose $files up -V --force-recreate --build

--- a/setupProxy.js
+++ b/setupProxy.js
@@ -1,5 +1,6 @@
 const proxy = require('http-proxy-middleware')
 const express = require('express')
+const router = express.Router()
 
 const apiOptions = {
   target: `http://${process.env.MARQUEZ_HOST}:${process.env.MARQUEZ_PORT}/`
@@ -11,6 +12,12 @@ app.use('/', express.static(path))
 app.use('/datasets/:name', express.static(path))
 app.use('/jobs/:name', express.static(path))
 app.use(proxy('/api/v1', apiOptions))
+
+router.get('/healthcheck', function (req, res) {
+  res.send('OK')
+})
+
+app.use(router)
 
 app.listen(3000, function() {
   console.log('App listening on port 3000!')


### PR DESCRIPTION
The PR adds a health endpoint:

#### Usage

```
GET /healthcheck

200 OK
```

This PR also adds the flag `--local` to `./docker.up.sh` providing the option to build images from source or pull from a remote repository (i.e docker hub).

#### Usage
```bash
$ ./docker.up.sh --local
``` 

/cc @frankcash thanks for the suggestion!
