### PR TITLE
Fix the lint toolchain

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,7 +9,7 @@ module.exports = {
     project: './tsconfig.json',
     sourceType: 'module'
   },
-  plugins: ['@typescript-eslint', 'react', 'prettier'],
+  plugins: ['@typescript-eslint', 'react', 'prettier', "sort-imports-es6-autofix"],
   extends: [
     'eslint:recommended',
     'plugin:react/recommended',
@@ -17,7 +17,11 @@ module.exports = {
     'plugin:@typescript-eslint/recommended',
     'prettier'
   ],
-  // ideally we keep these in alphabetical order
+  settings: {
+    "react": {
+      version: "detect"
+    }
+  },
   rules: {
     'react/prop-types': 'off',
     '@typescript-eslint/camelcase': 'off',
@@ -48,6 +52,11 @@ module.exports = {
     '@typescript-eslint/no-var-requires': 'off',
     quotes: 'off',
     '@typescript-eslint/quotes': ['error', 'single'],
-    '@typescript-eslint/semi': ['error', 'never']
+    '@typescript-eslint/semi': ['error', 'never'],
+    "sort-imports-es6-autofix/sort-imports-es6": [2, {
+      "ignoreCase": false,
+      "ignoreMemberSort": false,
+      "memberSyntaxSortOrder": ["none", "all", "multiple", "single"]
+    }]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .env.test.local
 .pnp.js
 .vscode
+.idea
 /.pnp
 /build
 /coverage

--- a/README.md
+++ b/README.md
@@ -98,23 +98,12 @@ This project is written in typescript. See [tsconfig.json](tsconfig.json) for ou
 
 Our types are defined in the `src/types` folder
 
-#### Linting
+#### Linting & Prettifying
 
-This project uses [ESLint with TypeScript support](https://github.com/typescript-eslint/typescript-eslint).
-
-If you have not already done so, you should [setup eslint with your editor of choice](https://eslint.org/docs/user-guide/integrations)
-
-You can add / edit the linting rules within the [eslintrc.js](eslintrc.js) file.
-
-### Prettifying
-
-We are using [Prettier](https://prettier.io/docs/en/install.html) to ensure uniform code style / formatting. Specifically, we are [using ESLint to run Prettier](https://prettier.io/docs/en/integrating-with-linters.html).
-
-1. Please set up [Prettier integration](https://prettier.io/docs/en/editors.html) with your editor of choice. (Also, be sure to disable any other prettifier, like HookyQR's Beautify tool, for this workspace.)
-
-2. Ensure that your editor formats on save.
-
-3. See [.prettierrc.js](.prettierrc.js) for our Prettier settings. See information on configuration settings [here](https://prettier.io/docs/en/configuration.html)
+Fix all style issues in project
+```
+   $ npm run eslint-fix 
+```
 
 ### Seeding data
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2228,7 +2228,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": ""
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
         }
       }
     },
@@ -4316,6 +4317,15 @@
             "esutils": "^2.0.2"
           }
         }
+      }
+    },
+    "eslint-plugin-sort-imports-es6-autofix": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-sort-imports-es6-autofix/-/eslint-plugin-sort-imports-es6-autofix-0.5.0.tgz",
+      "integrity": "sha512-KEX2Uz6bAs67jDYiH/OT1xz1E7AzIJJOIRg1F7OnFAfUVlpws3ldSZj5oZySRHfoVkWqDX9GGExYxckdLrWhwg==",
+      "dev": true,
+      "requires": {
+        "eslint": "^6.2.2"
       }
     },
     "eslint-scope": {
@@ -10774,7 +10784,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": ""
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "build": "webpack --config webpack.prod.js",
     "pretest": "eslint src/**/*[x]",
     "test": "jest",
-    "test-watch": "jest --watch"
+    "test-watch": "jest --watch",
+    "eslint-fix": "eslint . --ext .ts,.tsx --fix"
   },
   "engines": {
     "node": "10.16.3"
@@ -74,6 +75,7 @@
     "eslint-config-prettier": "^6.3.0",
     "eslint-plugin-prettier": "^3.1.1",
     "eslint-plugin-react": "^7.14.3",
+    "eslint-plugin-sort-imports-es6-autofix": "^0.5.0",
     "file-loader": "^3.0.1",
     "html-webpack-plugin": "^3.2.0",
     "identity-obj-proxy": "^3.0.0",

--- a/src/__tests__/components/AppBar.test.tsx
+++ b/src/__tests__/components/AppBar.test.tsx
@@ -1,8 +1,3 @@
-import { mount } from 'enzyme'
-import * as React from 'react'
-import AppBar from '../../components/AppBar'
-import { MemoryRouter } from 'react-router-dom'
-
 describe('AppBar Test', () => {
   // TODO: There's an issue with rendering this component in jest
 

--- a/src/__tests__/components/CustomSearchBar.test.tsx
+++ b/src/__tests__/components/CustomSearchBar.test.tsx
@@ -1,6 +1,5 @@
-import { shallow } from 'enzyme'
 import * as React from 'react'
-import Typography from '@material-ui/core/Typography'
+import { shallow } from 'enzyme'
 
 import CustomSearchBar from '../../components/CustomSearchBar'
 

--- a/src/__tests__/components/DatasetDetailPage.test.tsx
+++ b/src/__tests__/components/DatasetDetailPage.test.tsx
@@ -1,10 +1,9 @@
-import { mount } from 'enzyme'
 import * as React from 'react'
+import { mount } from 'enzyme'
 import Typography from '@material-ui/core/Typography'
-import Box from '@material-ui/core/Box'
 
-import DatasetDetailPage from '../../components/DatasetDetailPage'
 import { formatUpdatedAt } from '../../helpers'
+import DatasetDetailPage from '../../components/DatasetDetailPage'
 
 const datasets = require('../../../docker/db/data/datasets.json')
 const dataset = datasets[0]
@@ -55,7 +54,7 @@ describe('DatasetDetailPage Component', () => {
     it('should render', () => {
       expect(wrapper.exists()).toBe(true)
     })
-    it(`does not render 'no dataset'`, () => {
+    it('does not render \'no dataset\'', () => {
       expect(
         wrapper.findWhere(n =>
           n

--- a/src/__tests__/components/DatasetPreviewCard.test.tsx
+++ b/src/__tests__/components/DatasetPreviewCard.test.tsx
@@ -1,9 +1,9 @@
-import { mount } from 'enzyme'
 import * as React from 'react'
-import Typography from '@material-ui/core/Typography'
-import DatasetPreviewCard from '../../components/DatasetPreviewCard'
-import { formatUpdatedAt } from '../../helpers'
 import { MemoryRouter } from 'react-router-dom'
+import { formatUpdatedAt } from '../../helpers'
+import { mount } from 'enzyme'
+import DatasetPreviewCard from '../../components/DatasetPreviewCard'
+import Typography from '@material-ui/core/Typography'
 
 const datasets = require('../../../docker/db/data/datasets.json')
 const dataset = datasets[0]

--- a/src/__tests__/components/Dialog.test.tsx
+++ b/src/__tests__/components/Dialog.test.tsx
@@ -1,8 +1,7 @@
-import { shallow } from 'enzyme'
 import * as React from 'react'
-import { MemoryRouter } from 'react-router-dom'
+import { shallow } from 'enzyme'
+import Button from '@material-ui/core/Button'
 import Dialog from '../../components/Dialog'
-import Button from '@material-ui/core/Button';
 
 describe('Dialog Component', () => {
 

--- a/src/__tests__/components/Filters.test.tsx
+++ b/src/__tests__/components/Filters.test.tsx
@@ -1,5 +1,5 @@
-import { shallow } from 'enzyme'
 import * as React from 'react'
+import { shallow } from 'enzyme'
 import Filters from '../../components/filters/Filters'
 import Select from '@material-ui/core/Select'
 const namespaces = require('../../../docker/db/data/namespaces.json')

--- a/src/__tests__/components/JobDetailPage.test.tsx
+++ b/src/__tests__/components/JobDetailPage.test.tsx
@@ -1,11 +1,11 @@
-import { mount } from 'enzyme'
 import * as React from 'react'
-import Typography from '@material-ui/core/Typography'
+import { mount } from 'enzyme'
 import Box from '@material-ui/core/Box'
 import Tooltip from '@material-ui/core/Tooltip'
+import Typography from '@material-ui/core/Typography'
 
-import JobDetailPage from '../../components/JobDetailPage'
 import { formatUpdatedAt } from '../../helpers'
+import JobDetailPage from '../../components/JobDetailPage'
 
 const jobs = require('../../../docker/db/data/jobs.json')
 
@@ -210,7 +210,7 @@ test.skip('JobDetailPage Component', () => {
       expect(wrapper.exists()).toBe(true)
     })
 
-    it(`does not render 'no job'`, () => {
+    it('does not render \'no job\'', () => {
       expect(
         wrapper.findWhere(n =>
           n

--- a/src/__tests__/components/JobPreviewCard.test.tsx
+++ b/src/__tests__/components/JobPreviewCard.test.tsx
@@ -1,9 +1,9 @@
-import { mount } from 'enzyme'
 import * as React from 'react'
 import { MemoryRouter } from 'react-router-dom'
+import { mount } from 'enzyme'
 
-import JobPreviewCard from '../../components/JobPreviewCard'
 import { formatUpdatedAt } from '../../helpers'
+import JobPreviewCard from '../../components/JobPreviewCard'
 
 const jobs = require('../../../docker/db/data/jobs.json')
 

--- a/src/__tests__/components/Legend.test.tsx
+++ b/src/__tests__/components/Legend.test.tsx
@@ -1,5 +1,5 @@
-import { mount } from 'enzyme'
 import * as React from 'react'
+import { mount } from 'enzyme'
 
 import Legend from '../../components/Legend'
 
@@ -9,10 +9,10 @@ describe('Legend Component Tests', () => {
     expect(wrapper.exists()).toBe(true)
   })
   const componentText = wrapper.render().text()
-  it("Should render 'datasets' key", () => {
+  it('Should render \'datasets\' key', () => {
     expect(componentText).toContain('datasets')
   })
-  it("Should render 'jobs' key", () => {
+  it('Should render \'jobs\' key', () => {
     expect(componentText).toContain('jobs')
   })
 })

--- a/src/__tests__/components/Loader.test.tsx
+++ b/src/__tests__/components/Loader.test.tsx
@@ -1,5 +1,5 @@
-import { mount } from 'enzyme'
 import * as React from 'react'
+import { mount } from 'enzyme'
 import Loader from '../../components/Loader'
 
 describe('Loader Component', () => {

--- a/src/__tests__/components/NetworkGraph.test.tsx
+++ b/src/__tests__/components/NetworkGraph.test.tsx
@@ -1,9 +1,3 @@
-import { mount } from 'enzyme'
-import * as React from 'react'
-import { NetworkGraph } from '../../components/NetworkGraph'
-const jobs = require('../../../docker/db/data/jobs.json')
-const datasets = require('../../../docker/db/data/datasets.json')
-
 describe('NetworkGraph Component', () => {
   // TODO: There's an issue with rendering this component in jest
 

--- a/src/__tests__/components/Toast.test.tsx
+++ b/src/__tests__/components/Toast.test.tsx
@@ -1,5 +1,5 @@
-import { shallow } from 'enzyme'
 import * as React from 'react'
+import { shallow } from 'enzyme'
 import Toast from '../../components/Toast'
 
 describe('MainContainer Component', () => {

--- a/src/__tests__/helpers/index.test.ts
+++ b/src/__tests__/helpers/index.test.ts
@@ -19,13 +19,13 @@ describe('createNetworkData helper test', () => {
   it('should return as many nodes as there are jobs + datasets', () => {
     expect(networkData.nodes).toHaveLength(datasets.length + jobs.length)
   })
-  it(`should return as many links as there are jobs' inputs & outputs`, () => {
+  it('should return as many links as there are jobs\' inputs & outputs', () => {
     const linkCount = jobs.reduce((links, job) => {
       return (links += job.inputs.length + job.outputs.length)
     }, 0)
     expect(networkData.links).toHaveLength(linkCount)
   })
-  it(`each link should have a 'connectsToMatchingNode'`, () => {
+  it('each link should have a \'connectsToMatchingNode\'', () => {
     networkData.links.every(l => {
       expect(l).toHaveProperty('connectsToMatchingNode')
     })

--- a/src/__tests__/reducers/datasets.test.ts
+++ b/src/__tests__/reducers/datasets.test.ts
@@ -1,5 +1,5 @@
-import datasetsReducer, { initialState } from '../../reducers/datasets'
 import * as actionTypes from '../../constants/ActionTypes'
+import datasetsReducer, { initialState } from '../../reducers/datasets'
 
 const datasets = require('../../../docker/db/data/datasets.json')
 

--- a/src/__tests__/reducers/index.test.ts
+++ b/src/__tests__/reducers/index.test.ts
@@ -1,4 +1,4 @@
-import { findMatchingEntities, filterEntities } from '../../reducers'
+import { filterEntities, findMatchingEntities } from '../../reducers'
 
 describe('findMatchingEntities test', () => {
   const datasets = require('../../../docker/db/data/datasets.json')
@@ -7,7 +7,7 @@ describe('findMatchingEntities test', () => {
     expect(matchingDatasets.length).toStrictEqual(datasets.length)
   })
   matchingDatasets.forEach(d => {
-    it(`each item in returned array has a field called 'matches'`, () => {
+    it('each item in returned array has a field called \'matches\'', () => {
       expect(d).toHaveProperty('matches')
     })
   })
@@ -20,7 +20,7 @@ describe('filterEntitites test', () => {
     expect(matchingDatasets.length).toStrictEqual(datasets.length)
   })
   matchingDatasets.forEach(d => {
-    it(`each item in returned array has a field called 'matches'`, () => {
+    it('each item in returned array has a field called \'matches\'', () => {
       expect(d).toHaveProperty('matches')
     })
   })
@@ -28,7 +28,7 @@ describe('filterEntitites test', () => {
     const matchingDatasets = filterEntities(datasets, 'sourceName', datasets[0].sourceName)
     expect(matchingDatasets.filter(d => d.matches).length).toBeGreaterThan(0)
   })
-  it(`returns an array where every 'matches' field is true if we pass it a filterKey of 'all'`, () => {
+  it('returns an array where every \'matches\' field is true if we pass it a filterKey of \'all\'', () => {
     const matchingDatasets = filterEntities(datasets, 'all', datasets[0].sourceName)
     expect(matchingDatasets.filter(d => d.matches).length).toBe(datasets.length)
   })

--- a/src/__tests__/reducers/jobs.test.ts
+++ b/src/__tests__/reducers/jobs.test.ts
@@ -1,7 +1,7 @@
-import jobsReducer, { initialState } from '../../reducers/jobs'
-import _sample from 'lodash/sample'
-import _find from 'lodash/find'
 import * as actionTypes from '../../constants/ActionTypes'
+import _find from 'lodash/find'
+import _sample from 'lodash/sample'
+import jobsReducer, { initialState } from '../../reducers/jobs'
 
 const jobs = require('../../../docker/db/data/jobs.json')
 

--- a/src/__tests__/requests/index.test.ts
+++ b/src/__tests__/requests/index.test.ts
@@ -1,6 +1,6 @@
 
-import { genericFetchWrapper, parseResponse } from '../../requests'
 import * as requestUtils from '../../requests'
+import { parseResponse } from '../../requests'
 
 export const mockFetch = (requestBody: any = []) => {
   return jest.fn().mockImplementation(() => Promise.resolve({

--- a/src/__tests__/sagas/index.test.ts
+++ b/src/__tests__/sagas/index.test.ts
@@ -1,13 +1,13 @@
-import { expectSaga, testSaga } from 'redux-saga-test-plan'
-import * as matchers from 'redux-saga-test-plan/matchers'
-import * as actions from '../../actionCreators'
 import * as actionTypes from '../../constants/ActionTypes'
+import * as actions from '../../actionCreators'
 import * as api from '../../requests'
+import * as matchers from 'redux-saga-test-plan/matchers'
+import { expectSaga, testSaga } from 'redux-saga-test-plan'
 import { fetchNamespacesDatasetsAndJobs } from '../../sagas/'
 
 import { INamespaceAPI } from '../../types/api'
 
-describe("Main (That's so Fetch) Saga", () => {
+describe('Main (That\'s so Fetch) Saga', () => {
   const mockNamespaces: INamespaceAPI[] = [
     { name: 'Mock Namespace 1', description: '', createdAt: '', owner: 'CDA' },
     { name: 'Mock Namespace 2', description: '', createdAt: '', owner: 'CDA' }

--- a/src/actionCreators/index.ts
+++ b/src/actionCreators/index.ts
@@ -1,6 +1,6 @@
 import * as actionTypes from '../constants/ActionTypes'
 
-import { Namespace, Dataset, Job,Run } from '../types/api'
+import { Dataset, Job, Namespace,Run } from '../types/api'
 import { IFilterByKey } from '../types'
 
 export const fetchDatasetsSuccess = (datasets: Dataset[]) => ({

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,34 +1,34 @@
-import React, { ReactElement, useState } from 'react'
-import { Helmet } from 'react-helmet'
 import { CssBaseline } from '@material-ui/core'
+import { Helmet } from 'react-helmet'
 import AppBar from './AppBar'
+import React, { ReactElement, useState } from 'react'
 const globalStyles = require('../global_styles.css')
 const { neptune, telescopeBlack } = globalStyles
-import { Route, Switch } from 'react-router-dom'
+import { ConnectedRouter, routerMiddleware } from 'connected-react-router'
 import { Grid } from '@material-ui/core'
+import {
+  Theme as ITheme,
+  WithStyles as IWithStyles,
+  createStyles,
+  withStyles
+} from '@material-ui/core/styles'
 import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles'
-import { createStore, applyMiddleware } from 'redux'
 import { Provider } from 'react-redux'
-import logger from 'redux-logger'
-import createSagaMiddleware from 'redux-saga'
+import { Route, Switch } from 'react-router-dom'
+import { applyMiddleware, createStore } from 'redux'
 import { composeWithDevTools } from 'redux-devtools-extension'
 import { createBrowserHistory } from 'history'
-import { routerMiddleware, ConnectedRouter } from 'connected-react-router'
-import {
-  withStyles,
-  createStyles,
-  WithStyles as IWithStyles,
-  Theme as ITheme
-} from '@material-ui/core/styles'
+import createSagaMiddleware from 'redux-saga'
+import logger from 'redux-logger'
 
-import createRootReducer from '../reducers'
-import rootSaga from '../sagas'
 import CustomSearchBar from './CustomSearchBar'
 import DatasetDetailPage from './DatasetDetailPage'
+import Home from './Home'
 import JobDetailPage from './JobDetailPage'
 import NetworkGraph from './NetworkGraph'
 import Toast from './Toast'
-import Home from './Home'
+import createRootReducer from '../reducers'
+import rootSaga from '../sagas'
 
 const sagaMiddleware = createSagaMiddleware({
   onError: (error, _sagaStackIgnored) => {

--- a/src/components/AppBar.tsx
+++ b/src/components/AppBar.tsx
@@ -1,14 +1,14 @@
-import React, { ReactElement } from 'react'
 import { AppBar, Toolbar, Typography } from '@material-ui/core'
 import {
   Link
 } from 'react-router-dom'
+import React, { ReactElement } from 'react'
 
 import {
-  withStyles,
-  createStyles,
+  Theme as ITheme,
   WithStyles as IWithStyles,
-  Theme as ITheme
+  createStyles,
+  withStyles
 } from '@material-ui/core/styles'
 
 import Menu from './Menu'

--- a/src/components/CustomSearchBar.tsx
+++ b/src/components/CustomSearchBar.tsx
@@ -1,17 +1,16 @@
-import React, { FunctionComponent, useState } from 'react'
-import SearchBar from 'material-ui-search-bar'
-import { findMatchingEntities } from '../actionCreators'
-import {
-  withStyles,
-  createStyles,
-  WithStyles as IWithStyles,
-  Theme as ITheme
-} from '@material-ui/core/styles'
-
-import { useHistory } from 'react-router-dom'
 import * as Redux from 'redux'
+import {
+  Theme as ITheme,
+  WithStyles as IWithStyles,
+  createStyles,
+  withStyles
+} from '@material-ui/core/styles'
 import {bindActionCreators} from 'redux'
 import {connect} from 'react-redux'
+import { findMatchingEntities } from '../actionCreators'
+import { useHistory } from 'react-router-dom'
+import React, { FunctionComponent, useState } from 'react'
+import SearchBar from 'material-ui-search-bar'
 
 interface IProps {
   findMatchingEntities: typeof findMatchingEntities

--- a/src/components/DatasetDetailPage.tsx
+++ b/src/components/DatasetDetailPage.tsx
@@ -1,11 +1,11 @@
-import React, { FunctionComponent } from 'react'
+import { Box, Paper, Table, TableBody, TableCell, TableHead, TableRow, Tooltip, Typography } from '@material-ui/core'
 import {
-  withStyles,
-  createStyles,
+  Theme as ITheme,
   WithStyles as IWithStyles,
-  Theme as ITheme
+  createStyles,
+  withStyles
 } from '@material-ui/core/styles'
-import { Typography, Box, Tooltip, Table, TableCell, TableHead, TableRow, TableBody, Paper } from '@material-ui/core'
+import React, { FunctionComponent } from 'react'
 
 import InfoIcon from '@material-ui/icons/Info'
 
@@ -14,9 +14,9 @@ import { formatUpdatedAt } from '../helpers'
 import { useParams } from 'react-router-dom'
 import _find from 'lodash/find'
 
+import * as Redux from 'redux'
 import { Dataset } from '../types/api'
 import {IState} from '../reducers'
-import * as Redux from 'redux'
 import {bindActionCreators} from 'redux'
 import {connect} from 'react-redux'
 

--- a/src/components/DatasetPreviewCard.tsx
+++ b/src/components/DatasetPreviewCard.tsx
@@ -4,13 +4,13 @@ import {
   Link
 } from 'react-router-dom'
 
+import { Box, Typography } from '@material-ui/core'
 import {
-  withStyles,
-  createStyles,
+  Theme as ITheme,
   WithStyles as IWithStyles,
-  Theme as ITheme
+  createStyles,
+  withStyles
 } from '@material-ui/core/styles'
-import { Typography, Box } from '@material-ui/core'
 import { formatUpdatedAt } from '../helpers'
 
 import { Dataset } from '../types/api'

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react'
+import { dialogToggle } from '../actionCreators'
 import Button from '@material-ui/core/Button'
 import Dialog from '@material-ui/core/Dialog'
 import DialogActions from '@material-ui/core/DialogActions'
 import DialogContent from '@material-ui/core/DialogContent'
 import DialogContentText from '@material-ui/core/DialogContentText'
 import DialogTitle from '@material-ui/core/DialogTitle'
-import { dialogToggle } from '../actionCreators'
 
 interface IProps {
   dialogIsOpen: boolean

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -1,19 +1,19 @@
-import React, { FunctionComponent, useState } from 'react'
 import * as RRD from 'react-router-dom'
 import { Box, Typography } from '@material-ui/core'
+import React, { FunctionComponent, useState } from 'react'
 
 import Pagination from 'material-ui-flat-pagination'
 import _chunk from 'lodash/chunk'
 
 import {
-  withStyles,
-  createStyles,
+  Theme as ITheme,
   WithStyles as IWithStyles,
-  Theme as ITheme
+  createStyles,
+  withStyles
 } from '@material-ui/core/styles'
 
-import FiltersWrapper from './filters/FiltersWrapper'
 import DatasetPreviewCard from './DatasetPreviewCard'
+import FiltersWrapper from './filters/FiltersWrapper'
 import JobPreviewCard from './JobPreviewCard'
 
 import { IDatasetsState } from '../reducers/datasets'

--- a/src/components/JobDetailPage.tsx
+++ b/src/components/JobDetailPage.tsx
@@ -1,27 +1,27 @@
-import React, { FunctionComponent, useState, useEffect } from 'react'
-import {
-  withStyles,
-  createStyles,
-  WithStyles as IWithStyles,
-  Theme as ITheme
-} from '@material-ui/core/styles'
 import * as Redux from 'redux'
-import { Typography, Box, Fab, Tooltip } from '@material-ui/core'
-import CloseIcon from '@material-ui/icons/Close'
-import OpenWithSharpIcon from '@material-ui/icons/OpenWithSharp'
-import Modal from '@material-ui/core/Modal'
-import HowToRegIcon from '@material-ui/icons/HowToReg'
-import { useParams, useHistory } from 'react-router-dom'
-import _find from 'lodash/find'
-import { fetchJobRuns } from '../actionCreators'
+import { Box, Fab, Tooltip, Typography } from '@material-ui/core'
 import {IState} from '../reducers'
+import {
+  Theme as ITheme,
+  WithStyles as IWithStyles,
+  createStyles,
+  withStyles
+} from '@material-ui/core/styles'
 import {bindActionCreators} from 'redux'
 import {connect} from 'react-redux'
+import { fetchJobRuns } from '../actionCreators'
+import { useHistory, useParams } from 'react-router-dom'
+import CloseIcon from '@material-ui/icons/Close'
+import HowToRegIcon from '@material-ui/icons/HowToReg'
+import Modal from '@material-ui/core/Modal'
+import OpenWithSharpIcon from '@material-ui/icons/OpenWithSharp'
+import React, { FunctionComponent, useEffect, useState } from 'react'
+import _find from 'lodash/find'
 
 const globalStyles = require('../global_styles.css')
 const { jobRunNew, jobRunFailed, jobRunCompleted, jobRunAborted, jobRunRunning } = globalStyles
-import { formatUpdatedAt } from '../helpers'
 import { IJob } from '../types'
+import { formatUpdatedAt } from '../helpers'
 
 const colorMap = {
   NEW: jobRunNew,

--- a/src/components/JobPreviewCard.tsx
+++ b/src/components/JobPreviewCard.tsx
@@ -1,15 +1,15 @@
-import React, { ReactElement } from 'react'
 import {
-  withStyles,
-  createStyles,
+  Theme as ITheme,
   WithStyles as IWithStyles,
-  Theme as ITheme
+  createStyles,
+  withStyles
 } from '@material-ui/core/styles'
 import { Link } from 'react-router-dom'
+import React, { ReactElement } from 'react'
 
 const globalStyles = require('../global_styles.css')
 const { vibrantGreen } = globalStyles
-import { Typography, Box, Tooltip } from '@material-ui/core'
+import { Box, Tooltip, Typography } from '@material-ui/core'
 import { formatUpdatedAt } from '../helpers'
 
 import { Job } from '../types/api'

--- a/src/components/Legend.tsx
+++ b/src/components/Legend.tsx
@@ -1,11 +1,11 @@
-import React, { ReactElement } from 'react'
+import { Box, Typography } from '@material-ui/core'
 import {
-  withStyles,
-  createStyles,
+  Theme as ITheme,
   WithStyles as IWithStyles,
-  Theme as ITheme
+  createStyles,
+  withStyles
 } from '@material-ui/core/styles'
-import { Typography, Box } from '@material-ui/core'
+import React, { ReactElement } from 'react'
 const globalStyles = require('../global_styles.css')
 const { datasetNodeWhite } = globalStyles
 

--- a/src/components/Loader.tsx
+++ b/src/components/Loader.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
-import CircularProgress from '@material-ui/core/CircularProgress'
+import { WithStyles as IWithStyles, createStyles, withStyles } from '@material-ui/core/styles'
 import { styled } from '@material-ui/core/styles'
-import { withStyles, createStyles, WithStyles as IWithStyles } from '@material-ui/core/styles'
+import CircularProgress from '@material-ui/core/CircularProgress'
 
 interface IProps {}
 

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -1,8 +1,8 @@
-import React from 'react'
 import Button from '@material-ui/core/Button'
 import Menu from '@material-ui/core/Menu'
 import MenuIcon from '@material-ui/icons/Menu'
 import MenuItem from '@material-ui/core/MenuItem'
+import React from 'react'
 
 export default function SimpleMenu() {
   const [anchorEl, setAnchorEl] = React.useState(null)

--- a/src/components/NetworkGraph.tsx
+++ b/src/components/NetworkGraph.tsx
@@ -1,38 +1,38 @@
 import * as React from 'react'
 import * as d3 from 'd3'
 
-import {
-  withStyles,
-  createStyles,
-  WithStyles as IWithStyles,
-  Theme
-} from '@material-ui/core/styles'
-import {RouteComponentProps, withRouter} from 'react-router-dom'
 import {History} from 'history'
+import {RouteComponentProps, withRouter} from 'react-router-dom'
+import {
+  Theme,
+  WithStyles,
+  createStyles,
+  withStyles
+} from '@material-ui/core/styles'
 
 import Legend from './Legend'
 
 import {IDataset, IJob} from '../types/'
 
-import _find from 'lodash/find'
 import _filter from 'lodash/filter'
+import _find from 'lodash/find'
 import _flatten from 'lodash/flatten'
 import _map from 'lodash/map'
 import _sortBy from 'lodash/sortBy'
 
-import {select, event} from 'd3-selection'
+import {D3ZoomEvent} from 'd3'
+import {drag} from 'd3-drag'
+import {event, select} from 'd3-selection'
 import {hierarchy, tree} from 'd3-hierarchy'
 import {linkHorizontal} from 'd3-shape'
-import {drag} from 'd3-drag'
 import {zoom} from 'd3-zoom'
-import {D3ZoomEvent} from 'd3'
 
-import Loader from './Loader'
-import {Run} from '../types/api'
-import {IState} from '../reducers'
 import * as Redux from 'redux'
+import {IState} from '../reducers'
+import {Run} from '../types/api'
 import {bindActionCreators} from 'redux'
 import {connect} from 'react-redux'
+import Loader from './Loader'
 
 const globalStyles = require('../global_styles.css')
 const {jobRunNew, jobRunFailed, jobRunCompleted, jobRunAborted, jobRunRunning} = globalStyles
@@ -89,7 +89,7 @@ interface IProps {
   isLoading: boolean
 }
 
-type IAllProps = IWithStyles<typeof styles> & IProps & RouteComponentProps
+type IAllProps = WithStyles<typeof styles> & IProps & RouteComponentProps
 
 export class NetworkGraph extends React.Component<IAllProps> {
 

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
-import {IState} from '../reducers'
 import * as Redux from 'redux'
+import {IState} from '../reducers'
 import {bindActionCreators} from 'redux'
 import {connect} from 'react-redux'
 const styles = require('./Toast.css')

--- a/src/components/filters/Filters.tsx
+++ b/src/components/filters/Filters.tsx
@@ -1,13 +1,13 @@
-import React, { ReactElement, useState, ChangeEvent } from 'react'
-import MUISelect from '@material-ui/core/Select'
-import MenuItem from '@material-ui/core/MenuItem'
-import Box from '@material-ui/core/Box'
-import FormControl from '@material-ui/core/FormControl'
-import uniq from 'lodash/uniq'
-import { withStyles } from '@material-ui/core/styles'
-import { capitalize } from '../../helpers'
 import { IProps } from './FiltersWrapper'
 import { Namespace } from '../../types/api'
+import { capitalize } from '../../helpers'
+import { withStyles } from '@material-ui/core/styles'
+import Box from '@material-ui/core/Box'
+import FormControl from '@material-ui/core/FormControl'
+import MUISelect from '@material-ui/core/Select'
+import MenuItem from '@material-ui/core/MenuItem'
+import React, { ChangeEvent, ReactElement, useState } from 'react'
+import uniq from 'lodash/uniq'
 
 const StyledFormControl = withStyles({
   root: {

--- a/src/components/filters/FiltersWrapper.tsx
+++ b/src/components/filters/FiltersWrapper.tsx
@@ -1,12 +1,12 @@
-import { connect } from 'react-redux'
 import * as Redux from 'redux'
-import { bindActionCreators } from 'redux'
-import Filters from './Filters'
 import { IState } from '../../reducers'
+import { bindActionCreators } from 'redux'
+import { connect } from 'react-redux'
+import Filters from './Filters'
 
-import { findMatchingEntities, filterDatasets, filterJobs } from '../../actionCreators'
+import { Dataset, Namespace } from '../../types/api'
+import { filterDatasets, filterJobs, findMatchingEntities } from '../../actionCreators'
 import React, { FunctionComponent } from 'react'
-import { Namespace, Dataset } from '../../types/api'
 
 export interface IProps {
   namespaces: Namespace[]

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,6 +1,6 @@
-import { IDataset, IJob, INetworkData, INodeNetwork, INetworkLink } from '../types/'
-import _find from 'lodash/find'
+import { IDataset, IJob, INetworkData, INetworkLink, INodeNetwork } from '../types/'
 import { isoParse, timeFormat } from 'd3-time-format'
+import _find from 'lodash/find'
 
 export const createNetworkData = (datasets: IDataset[], jobs: IJob[]): INetworkData => {
   const datasetNodes: INodeNetwork[] = datasets.map(d => ({

--- a/src/reducers/datasets.ts
+++ b/src/reducers/datasets.ts
@@ -1,15 +1,15 @@
-import { IDataset } from '../types'
-import { findMatchingEntities, filterEntities } from './'
 import {
   FETCH_DATASETS_SUCCESS,
-  FIND_MATCHING_ENTITIES,
-  FILTER_DATASETS
+  FILTER_DATASETS,
+  FIND_MATCHING_ENTITIES
 } from '../constants/ActionTypes'
+import { IDataset } from '../types'
 import {
   fetchDatasetsSuccess,
-  findMatchingEntities as findMatchingEntitiesActionCreator,
-  filterDatasets
+  filterDatasets,
+  findMatchingEntities as findMatchingEntitiesActionCreator
 } from '../actionCreators'
+import { filterEntities, findMatchingEntities } from './'
 
 export type IDatasetsState = IDataset[]
 

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -1,11 +1,11 @@
-import { combineReducers, Reducer } from 'redux'
-import { connectRouter } from 'connected-react-router'
-import datasets, { IDatasetsState } from './datasets'
-import jobs, { IJobsState } from './jobs'
-import namespaces, { INamespacesState } from './namespaces'
-import display, { IDisplayState } from './display'
 import { History } from 'history'
 import { IFilterByKey } from '../types'
+import { Reducer, combineReducers } from 'redux'
+import { connectRouter } from 'connected-react-router'
+import datasets, { IDatasetsState } from './datasets'
+import display, { IDisplayState } from './display'
+import jobs, { IJobsState } from './jobs'
+import namespaces, { INamespacesState } from './namespaces'
 
 export interface IState {
   datasets: IDatasetsState

--- a/src/reducers/jobs.ts
+++ b/src/reducers/jobs.ts
@@ -1,18 +1,18 @@
-import { IJob } from '../types'
-import _find from 'lodash/find'
-import { findMatchingEntities, filterEntities } from './'
 import {
   FETCH_JOBS_SUCCESS,
-  FIND_MATCHING_ENTITIES,
+  FETCH_JOB_RUNS_SUCCESS,
   FILTER_JOBS,
-  FETCH_JOB_RUNS_SUCCESS
+  FIND_MATCHING_ENTITIES
 } from '../constants/ActionTypes'
+import { IJob } from '../types'
 import {
+  fetchJobRunsSuccess,
   fetchJobsSuccess,
-  findMatchingEntities as findMatchingEntitiesActionCreator,
   filterJobs,
-  fetchJobRunsSuccess
+  findMatchingEntities as findMatchingEntitiesActionCreator
 } from '../actionCreators'
+import { filterEntities, findMatchingEntities } from './'
+import _find from 'lodash/find'
 
 export type IJobsState = IJob[]
 

--- a/src/requests/datasets.ts
+++ b/src/requests/datasets.ts
@@ -1,5 +1,5 @@
+import { Datasets, Namespace } from '../types/api'
 import { genericFetchWrapper } from '.'
-import { Namespace, Datasets } from '../types/api'
 
 export const fetchDatasets = async (namespace: Namespace) => {
   const { name } = namespace

--- a/src/requests/index.ts
+++ b/src/requests/index.ts
@@ -1,4 +1,4 @@
-import { HttpMethod, APIError } from '../types'
+import { APIError, HttpMethod } from '../types'
 
 export const genericErrorMessageConstructor = (functionName: string, error: APIError): string => {
   const { code, message, details } = error

--- a/src/requests/jobs.ts
+++ b/src/requests/jobs.ts
@@ -1,5 +1,5 @@
+import { Job, Jobs, Namespace, Run } from '../types/api'
 import { genericFetchWrapper } from '.'
-import { Job, Namespace, Jobs, Run } from '../types/api'
 
 export const fetchJobs = async (namespace: Namespace) => {
   const { name } = namespace

--- a/src/requests/namespaces.ts
+++ b/src/requests/namespaces.ts
@@ -1,5 +1,5 @@
-import { genericFetchWrapper } from '.'
 import { Namespaces } from '../types/api'
+import { genericFetchWrapper } from '.'
 
 export const fetchNamespaces = async () => {
   const url = `${__API_URL__}/namespaces`

--- a/src/sagas/index.ts
+++ b/src/sagas/index.ts
@@ -1,16 +1,15 @@
-import { all, call, put, take } from 'redux-saga/effects'
-import * as RS from 'redux-saga'
-import _orderBy from 'lodash/orderBy'
-import { Namespace, Namespaces  } from '../types/api'
-import { fetchNamespaces, fetchDatasets, fetchJobs, fetchLatestJobRuns } from '../requests'
-import {
-  fetchDatasetsSuccess,
-  fetchJobsSuccess,
-  fetchNamespacesSuccess,
-  fetchJobRunsSuccess,
-  applicationError
-} from '../actionCreators'
 import { FETCH_JOB_RUNS } from '../constants/ActionTypes'
+import { Namespace, Namespaces  } from '../types/api'
+import { all, call, put, take } from 'redux-saga/effects'
+import {
+  applicationError,
+  fetchDatasetsSuccess,
+  fetchJobRunsSuccess,
+  fetchJobsSuccess,
+  fetchNamespacesSuccess
+} from '../actionCreators'
+import { fetchDatasets, fetchJobs, fetchLatestJobRuns, fetchNamespaces } from '../requests'
+import _orderBy from 'lodash/orderBy'
 
 export function* fetchNamespacesDatasetsAndJobs() {
   try {

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,26 +1,26 @@
 export interface Tag {
-  name: string;
-  description: string;
+  name: string
+  description: string
 }
 export interface Runs {
-  runs: Run[];
-}
-
-export interface Runs {
-  runs: Run[];
+  runs: Run[]
 }
 
 export interface Runs {
-  runs: Run[];
+  runs: Run[]
 }
 
 export interface Runs {
-  runs: Run[];
+  runs: Run[]
+}
+
+export interface Runs {
+  runs: Run[]
 }
 
 
 export interface Namespaces {
-  namespaces: Namespace[];
+  namespaces: Namespace[]
 }
 
 export interface Namespace {
@@ -32,30 +32,30 @@ export interface Namespace {
 }
 
 export interface Datasets {
-  datasets: Dataset[];
+  datasets: Dataset[]
 }
 
 export interface Dataset {
-  id: DatasetId;
-  type: DatasetType;
-  name: string;
-  physicalName: string;
-  createdAt: string;
-  updatedAt: string;
-  namespace: string;
-  sourceName: string;
-  fields: Field[];
-  tags: string[];
-  lastModifiedAt: string;
-  description: string;
+  id: DatasetId
+  type: DatasetType
+  name: string
+  physicalName: string
+  createdAt: string
+  updatedAt: string
+  namespace: string
+  sourceName: string
+  fields: Field[]
+  tags: string[]
+  lastModifiedAt: string
+  description: string
 }
 
 export interface DatasetId {
-  namespace: string;
-  name: string;
+  namespace: string
+  name: string
 }
 
-export type DatasetType = "DB_TABLE" | "STREAM";
+export type DatasetType = 'DB_TABLE' | 'STREAM'
 
 export interface Field {
   name: string
@@ -65,51 +65,51 @@ export interface Field {
 }
 
 export interface Jobs {
-  jobs: Job[];
+  jobs: Job[]
 }
 
 
 export interface Job {
-  id: JobId;
-  type: JobType;
-  name: string;
-  createdAt: string;
-  updatedAt: string;
-  inputs: DatasetId[];
-  outputs: DatasetId[];
-  namespace: string;
-  location: string;
+  id: JobId
+  type: JobType
+  name: string
+  createdAt: string
+  updatedAt: string
+  inputs: DatasetId[]
+  outputs: DatasetId[]
+  namespace: string
+  location: string
   context: {
-    [key: string]: string;
-  };
-  description: string;
-  latestRun: Run;
+    [key: string]: string
+  }
+  description: string
+  latestRun: Run
 }
 
 export interface JobId {
-  namespace: string;
-  name: string;
+  namespace: string
+  name: string
 }
 
-export type JobType = "BATCH" | "STREAM" | "SERVICE";
+export type JobType = 'BATCH' | 'STREAM' | 'SERVICE'
 
 export interface Runs {
-  runs: Run[];
+  runs: Run[]
 }
 
 export interface Run {
-  id: string;
-  createdAt: string;
-  updatedAt: string;
-  nominalStartTime: string;
-  nominalEndTime: string;
-  state: RunState;
-  startedAt: string;
-  endedAt: string;
-  durationMs: number;
+  id: string
+  createdAt: string
+  updatedAt: string
+  nominalStartTime: string
+  nominalEndTime: string
+  state: RunState
+  startedAt: string
+  endedAt: string
+  durationMs: number
   args: {
-    [key: string]: string;
-  };
+    [key: string]: string
+  }
 }
 
-export type RunState = "NEW" | "COMPLETED" | "FAILED" | "ABORTED";
+export type RunState = 'NEW' | 'COMPLETED' | 'FAILED' | 'ABORTED'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,5 @@
     "skipLibCheck": true,
     "esModuleInterop": true
   },
-  "include": ["./src/**/*"],
-  "exclude": ["./src/__tests__/**/*"]
+  "include": ["./src/**/*"]
 }


### PR DESCRIPTION
### Description
This fixes the overall lint configuration for the project as a whole and applies the formatting rules to both the code and the tests. It also adds a new rule to sort our imports and fix them automatically.

###### Usage

```bash
npm run eslint-fix 
```

> Note: Eventually we'll add a step to CI to check for a valid lint config.


